### PR TITLE
refactor: extract shared getTodayString() to utils/dates

### DIFF
--- a/src/pages/GuessThePlayer/helpers.ts
+++ b/src/pages/GuessThePlayer/helpers.ts
@@ -4,10 +4,8 @@ import type { DailyResult, GuessStats } from "./types";
 import type { FormerTeam } from "../../types";
 import type { MergedClub } from "../../components/PlayerCard/types";
 
-export function getTodayString(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
+import { getTodayString } from "../../utils/dates";
+export { getTodayString };
 
 // Fallback daily player selection used when Supabase is unavailable.
 // Sequential day-number indexing: day 1 = index 0, day 2 = index 1, etc.

--- a/src/pages/GuessThePlayer/index.tsx
+++ b/src/pages/GuessThePlayer/index.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useGuessGame } from "./useGuessGame";
 import { HARD_MODE_KEY } from "./constants";
-import { mergeConsecutiveClubs } from "./helpers";
+import { mergeConsecutiveClubs, getTodayString } from "./helpers";
 import PlayerCard from "../../components/PlayerCard";
 
 export default function GuessThePlayer() {
@@ -33,9 +33,7 @@ export default function GuessThePlayer() {
       const stored = localStorage.getItem(HARD_MODE_KEY);
       if (!stored) return false;
       const parsed = JSON.parse(stored);
-      const d = new Date();
-      const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-      return parsed.date === today;
+      return parsed.date === getTodayString();
     } catch {
       return false;
     }
@@ -45,9 +43,7 @@ export default function GuessThePlayer() {
 
   function toggleHardMode() {
     if (hardMode) {
-      const d = new Date();
-      const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-      localStorage.setItem(HARD_MODE_KEY, JSON.stringify({ date: today }));
+      localStorage.setItem(HARD_MODE_KEY, JSON.stringify({ date: getTodayString() }));
       setHardMode(false);
     }
   }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,15 +1,14 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { DAILY_GUESS_KEY } from "../GuessThePlayer/constants";
+import { getTodayString } from "../../utils/dates";
 
 function isDailyCompleted(): boolean {
   try {
     const stored = localStorage.getItem(DAILY_GUESS_KEY);
     if (!stored) return false;
     const parsed = JSON.parse(stored);
-    const d = new Date();
-    const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-    return parsed.date === today;
+    return parsed.date === getTodayString();
   } catch {
     return false;
   }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,4 @@
+export function getTodayString(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- Extract `getTodayString()` to `src/utils/dates.ts`
- Replace 4 inline date formatting patterns across Home, GuessThePlayer index, and helpers
- helpers.ts re-exports for backwards compatibility with existing imports

## Test plan
- [x] Type check passes
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)