### PR TITLE
feat: admin interface for daily schedule and club management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
 # Or if Supabase provides a publishable key instead:
 # VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key-here
+
+# Admin interface passphrase (required for /#/admin access)
+VITE_ADMIN_PASSPHRASE=your-admin-passphrase-here

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
+import { lazy, Suspense } from "react";
 import { HashRouter, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Battle from "./pages/Battle";
 import GuessThePlayer from "./pages/GuessThePlayer";
 import GuessArchive from "./pages/GuessThePlayer/Archive";
 import MultiplayerBattle from "./pages/MultiplayerBattle";
+
+const Admin = lazy(() => import("./pages/Admin"));
 
 function App() {
   return (
@@ -14,6 +17,7 @@ function App() {
         <Route path="/battle/multiplayer" element={<MultiplayerBattle />} />
         <Route path="/guess" element={<GuessThePlayer />} />
         <Route path="/guess/archive" element={<GuessArchive />} />
+        <Route path="/admin" element={<Suspense fallback={null}><Admin /></Suspense>} />
       </Routes>
     </HashRouter>
   );

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,0 +1,151 @@
+import { supabase } from "./supabaseClient";
+import type { AdminClubRow } from "../pages/Admin/types";
+
+// --- Schedule operations ---
+
+export async function upsertSchedule(date: string, playerId: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("daily_schedule")
+    .upsert({ date, player_id: playerId }, { onConflict: "date" });
+  return !error;
+}
+
+export async function deleteSchedule(date: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("daily_schedule")
+    .delete()
+    .eq("date", date);
+  return !error;
+}
+
+export async function getScheduleRange(
+  fromDate: string,
+  toDate: string,
+): Promise<{ date: string; player_id: string }[]> {
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from("daily_schedule")
+    .select("date, player_id")
+    .gte("date", fromDate)
+    .lte("date", toDate)
+    .order("date");
+  return data ?? [];
+}
+
+// --- Club history operations ---
+
+export async function getPlayerClubsAdmin(playerId: string): Promise<AdminClubRow[]> {
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from("player_clubs")
+    .select("id, club_id, year_joined, year_departed, is_hidden, sort_order, clubs(name, badge)")
+    .eq("player_id", playerId)
+    .order("sort_order", { ascending: true, nullsFirst: false })
+    .order("year_joined", { ascending: true });
+  if (!data) return [];
+  return (data as unknown as Array<{
+    id: number;
+    club_id: string;
+    year_joined: string;
+    year_departed: string;
+    is_hidden: boolean;
+    sort_order: number | null;
+    clubs: { name: string; badge: string } | null;
+  }>).map((row) => ({
+    id: row.id,
+    club_id: row.club_id,
+    club_name: row.clubs?.name ?? row.club_id,
+    badge: row.clubs?.badge ?? "",
+    year_joined: row.year_joined,
+    year_departed: row.year_departed,
+    is_hidden: row.is_hidden,
+    sort_order: row.sort_order,
+  }));
+}
+
+export async function updatePlayerClubHidden(
+  playerClubId: number,
+  isHidden: boolean,
+): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("player_clubs")
+    .update({ is_hidden: isHidden })
+    .eq("id", playerClubId);
+  return !error;
+}
+
+// --- Club reorder operations ---
+
+export async function updateClubSortOrders(
+  updates: { id: number; sort_order: number }[],
+): Promise<boolean> {
+  if (!supabase) return false;
+  for (const { id, sort_order } of updates) {
+    const { error } = await supabase
+      .from("player_clubs")
+      .update({ sort_order })
+      .eq("id", id);
+    if (error) return false;
+  }
+  return true;
+}
+
+// --- Club name operations ---
+
+export async function updateClubName(clubId: string, name: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("clubs")
+    .update({ name })
+    .eq("id", clubId);
+  return !error;
+}
+
+// --- Club crest operations ---
+
+export async function searchClubs(query: string): Promise<{ id: string; name: string; badge: string }[]> {
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from("clubs")
+    .select("id, name, badge")
+    .ilike("name", `%${query}%`)
+    .limit(20);
+  return data ?? [];
+}
+
+export async function uploadClubCrest(clubId: string, file: File): Promise<string | null> {
+  if (!supabase) return null;
+  const ext = file.name.split(".").pop() ?? "png";
+  const path = `${clubId}.${ext}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from("club-crests")
+    .upload(path, file, { upsert: true });
+  if (uploadError) return null;
+
+  const { data: urlData } = supabase.storage
+    .from("club-crests")
+    .getPublicUrl(path);
+
+  const publicUrl = urlData.publicUrl;
+
+  // Update the club record with the new badge URL
+  await supabase
+    .from("clubs")
+    .update({ badge: publicUrl })
+    .eq("id", clubId);
+
+  return publicUrl;
+}
+
+export async function updateClubBadge(clubId: string, badgeUrl: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("clubs")
+    .update({ badge: badgeUrl })
+    .eq("id", clubId);
+  return !error;
+}

--- a/src/api/playerCache.ts
+++ b/src/api/playerCache.ts
@@ -64,6 +64,8 @@ interface PlayerClubRow {
   club_id: string;
   year_joined: string;
   year_departed: string;
+  is_hidden?: boolean;
+  sort_order?: number | null;
   clubs: { id: string; name: string; badge: string } | null;
 }
 
@@ -79,7 +81,7 @@ interface PlayerRow {
   countries: { name: string } | null;
 }
 
-const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, countries(name), player_clubs(club_id, year_joined, year_departed, clubs(id, name, badge))";
+const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, countries(name), player_clubs(club_id, year_joined, year_departed, is_hidden, sort_order, clubs(id, name, badge))";
 
 let countryNamesCache: Set<string> | null = null;
 
@@ -150,23 +152,36 @@ async function getFromCache(playerId: string, playerName?: string): Promise<Play
 
 async function buildPlayerWithTeams(row: PlayerRow): Promise<PlayerWithTeams> {
   const countryNames = await getCountryNames();
-  const rawTeams: FormerTeam[] = row.player_clubs
+  const filtered = row.player_clubs
     .filter((pc) => pc.clubs)
-    .filter((pc) => !isNationalTeam(pc.clubs!.name, countryNames))
-    .map((pc) => ({
-      teamId: pc.clubs!.id,
-      teamName: pc.clubs!.name,
-      yearJoined: pc.year_joined,
-      yearDeparted: pc.year_departed,
-      badge: pc.clubs!.badge,
-    }));
+    .filter((pc) => !pc.is_hidden)
+    .filter((pc) => !isNationalTeam(pc.clubs!.name, countryNames));
+
+  // Use explicit sort_order if any club has one set, otherwise fall back to year-based sort
+  const hasCustomOrder = filtered.some((pc) => pc.sort_order != null);
+
+  if (hasCustomOrder) {
+    filtered.sort((a, b) => (a.sort_order ?? 9999) - (b.sort_order ?? 9999));
+  }
+
+  const rawTeams: FormerTeam[] = filtered.map((pc) => ({
+    teamId: pc.clubs!.id,
+    teamName: pc.clubs!.name,
+    yearJoined: pc.year_joined,
+    yearDeparted: pc.year_departed,
+    badge: pc.clubs!.badge,
+  }));
+
+  const orderedTeams = hasCustomOrder
+    ? rawTeams
+    : sortAndMergeTeams(rawTeams);
 
   return {
     id: row.id,
     name: row.name,
     thumbnail: row.thumbnail,
     nationality: row.countries?.name ?? row.nationality_id ?? "",
-    formerTeams: sortAndMergeTeams(rawTeams),
+    formerTeams: orderedTeams,
     cachedAt: row.cached_at,
     position: row.position || undefined,
     dateBorn: row.date_born || undefined,

--- a/src/pages/Admin/CrestDropZone.tsx
+++ b/src/pages/Admin/CrestDropZone.tsx
@@ -1,0 +1,104 @@
+import { useState, useRef, useCallback } from "react";
+import { uploadClubCrest } from "../../api/adminApi";
+
+interface Props {
+  clubId: string;
+  currentBadge: string;
+  clubName: string;
+  onUpdated: (newUrl: string) => void;
+}
+
+const ACCEPTED_TYPES = ["image/png", "image/jpeg", "image/svg+xml", "image/webp"];
+
+export default function CrestDropZone({ clubId, currentBadge, clubName, onUpdated }: Props) {
+  const [dragging, setDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [imgError, setImgError] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback(
+    async (file: File) => {
+      if (!ACCEPTED_TYPES.includes(file.type)) return;
+      setUploading(true);
+      const url = await uploadClubCrest(clubId, file);
+      setUploading(false);
+      if (url) {
+        setImgError(false);
+        onUpdated(url);
+      }
+    },
+    [clubId, onUpdated],
+  );
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(true);
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  }
+
+  function handleClick() {
+    fileInputRef.current?.click();
+  }
+
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    // Reset so the same file can be re-selected
+    e.target.value = "";
+  }
+
+  const hasBadge = currentBadge && !imgError;
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      className={`relative w-10 h-10 shrink-0 rounded cursor-pointer transition-all ${
+        dragging
+          ? "ring-2 ring-green-500 bg-green-900/30"
+          : "hover:ring-2 hover:ring-gray-500"
+      }`}
+      title={`Click or drag to upload crest for ${clubName}`}
+    >
+      {uploading ? (
+        <div className="w-full h-full flex items-center justify-center bg-gray-700 rounded">
+          <div className="w-5 h-5 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : hasBadge ? (
+        <img
+          src={currentBadge}
+          alt={clubName}
+          className="w-full h-full object-contain"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <div className="w-full h-full bg-gray-700 rounded flex items-center justify-center">
+          <span className="text-gray-500 text-xs font-bold">
+            {clubName.slice(0, 2).toUpperCase()}
+          </span>
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_TYPES.join(",")}
+        onChange={handleFileInput}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  getPlayerClubsAdmin,
+  updatePlayerClubHidden,
+  updateClubSortOrders,
+  updateClubName,
+} from "../../api/adminApi";
+import type { AdminClubRow } from "./types";
+import CrestDropZone from "./CrestDropZone";
+
+interface Props {
+  playerId: string;
+}
+
+export default function PlayerClubList({ playerId }: Props) {
+  const [clubs, setClubs] = useState<AdminClubRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingNameId, setEditingNameId] = useState<number | null>(null);
+  const [editNameValue, setEditNameValue] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    getPlayerClubsAdmin(playerId).then((data) => {
+      if (!cancelled) {
+        setClubs(data);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [playerId]);
+
+  async function toggleHidden(club: AdminClubRow) {
+    const newHidden = !club.is_hidden;
+    const ok = await updatePlayerClubHidden(club.id, newHidden);
+    if (ok) {
+      setClubs((prev) =>
+        prev.map((c) => (c.id === club.id ? { ...c, is_hidden: newHidden } : c)),
+      );
+    }
+  }
+
+  function handleCrestUpdated(clubId: string, newBadgeUrl: string) {
+    setClubs((prev) =>
+      prev.map((c) => (c.club_id === clubId ? { ...c, badge: newBadgeUrl } : c)),
+    );
+  }
+
+  const moveClub = useCallback(async (index: number, direction: -1 | 1) => {
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= clubs.length) return;
+
+    const newClubs = [...clubs];
+    [newClubs[index], newClubs[targetIndex]] = [newClubs[targetIndex], newClubs[index]];
+
+    // Assign sort_order 0, 1, 2, ... to all clubs
+    const updates = newClubs.map((c, i) => ({ id: c.id, sort_order: i }));
+    const updatedClubs = newClubs.map((c, i) => ({ ...c, sort_order: i }));
+
+    setClubs(updatedClubs);
+    await updateClubSortOrders(updates);
+  }, [clubs]);
+
+  function startEditName(club: AdminClubRow) {
+    setEditingNameId(club.id);
+    setEditNameValue(club.club_name);
+  }
+
+  async function saveEditName(club: AdminClubRow) {
+    const trimmed = editNameValue.trim();
+    if (!trimmed || trimmed === club.club_name) {
+      setEditingNameId(null);
+      return;
+    }
+    const ok = await updateClubName(club.club_id, trimmed);
+    if (ok) {
+      setClubs((prev) =>
+        prev.map((c) => (c.club_id === club.club_id ? { ...c, club_name: trimmed } : c)),
+      );
+    }
+    setEditingNameId(null);
+  }
+
+  function handleNameKeyDown(e: React.KeyboardEvent, club: AdminClubRow) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveEditName(club);
+    } else if (e.key === "Escape") {
+      setEditingNameId(null);
+    }
+  }
+
+  if (loading) {
+    return <p className="text-gray-500 text-sm py-2">Loading clubs...</p>;
+  }
+
+  if (clubs.length === 0) {
+    return <p className="text-gray-500 text-sm py-2">No club history found.</p>;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs text-gray-500 mb-2">
+        Drag badge to upload crest. Click name to edit. Arrows to reorder.
+      </p>
+      {clubs.map((club, index) => (
+        <div
+          key={club.id}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-opacity ${
+            club.is_hidden ? "opacity-40" : ""
+          }`}
+        >
+          {/* Reorder buttons */}
+          <div className="flex flex-col shrink-0">
+            <button
+              onClick={() => moveClub(index, -1)}
+              disabled={index === 0}
+              className="text-gray-500 hover:text-white disabled:opacity-20 disabled:cursor-default p-0.5 transition-colors"
+              title="Move up"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              </svg>
+            </button>
+            <button
+              onClick={() => moveClub(index, 1)}
+              disabled={index === clubs.length - 1}
+              className="text-gray-500 hover:text-white disabled:opacity-20 disabled:cursor-default p-0.5 transition-colors"
+              title="Move down"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Badge with drop zone */}
+          <CrestDropZone
+            clubId={club.club_id}
+            currentBadge={club.badge}
+            clubName={club.club_name}
+            onUpdated={(url) => handleCrestUpdated(club.club_id, url)}
+          />
+
+          {/* Club info */}
+          <div className="flex-1 min-w-0">
+            {editingNameId === club.id ? (
+              <input
+                type="text"
+                value={editNameValue}
+                onChange={(e) => setEditNameValue(e.target.value)}
+                onBlur={() => saveEditName(club)}
+                onKeyDown={(e) => handleNameKeyDown(e, club)}
+                className="text-sm font-medium bg-gray-700 text-white px-2 py-0.5 rounded border border-gray-500 focus:outline-none focus:border-green-500 w-full"
+                autoFocus
+              />
+            ) : (
+              <button
+                onClick={() => startEditName(club)}
+                className={`text-sm font-medium text-left cursor-text hover:underline ${
+                  club.is_hidden ? "line-through text-gray-500" : "text-white"
+                }`}
+                title="Click to edit name"
+              >
+                {club.club_name}
+              </button>
+            )}
+            <div className="text-xs text-gray-500">
+              {club.year_joined || "?"} – {club.year_departed || "present"}
+            </div>
+          </div>
+
+          {/* Hide/show toggle */}
+          <button
+            onClick={() => toggleHidden(club)}
+            title={club.is_hidden ? "Show this club" : "Hide this club"}
+            className={`p-1.5 rounded transition-colors ${
+              club.is_hidden
+                ? "text-gray-500 hover:text-white hover:bg-gray-700"
+                : "text-gray-400 hover:text-red-400 hover:bg-gray-700"
+            }`}
+          >
+            {club.is_hidden ? (
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21" />
+              </svg>
+            ) : (
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            )}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Admin/ScheduleManager.tsx
+++ b/src/pages/Admin/ScheduleManager.tsx
@@ -1,0 +1,262 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { SEED_PLAYERS } from "../../data/seedPlayers";
+import { getAllScheduledDays } from "../../api/dailySchedule";
+import { upsertSchedule, deleteSchedule, getScheduleRange } from "../../api/adminApi";
+import { SCHEDULE_DAYS_AHEAD } from "./constants";
+import type { Player } from "../../types";
+import PlayerClubList from "./PlayerClubList";
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00");
+  return d.toLocaleDateString("en-GB", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function getTodayString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getDateRange(days: number): string[] {
+  const today = new Date();
+  const dates: string[] = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(today.getDate() + i);
+    dates.push(d.toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+interface DayState {
+  date: string;
+  assignedPlayer: Player | null;
+  suggestion: Player | null;
+}
+
+export default function ScheduleManager() {
+  const [days, setDays] = useState<DayState[]>([]);
+  const [usedPlayerIds, setUsedPlayerIds] = useState<Set<string>>(new Set());
+  const [expandedDate, setExpandedDate] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const today = useMemo(() => getTodayString(), []);
+
+  const getRandomUnused = useCallback(
+    (excludeIds: Set<string>): Player | null => {
+      const available = SEED_PLAYERS.filter((p) => !excludeIds.has(p.id));
+      if (available.length === 0) return null;
+      return available[Math.floor(Math.random() * available.length)];
+    },
+    [],
+  );
+
+  const loadSchedule = useCallback(async () => {
+    setLoading(true);
+    const dates = getDateRange(SCHEDULE_DAYS_AHEAD);
+    const [allUsed, rangeData] = await Promise.all([
+      getAllScheduledDays(),
+      getScheduleRange(dates[0], dates[dates.length - 1]),
+    ]);
+
+    const allUsedIds = new Set(allUsed.map((r) => r.player_id));
+    setUsedPlayerIds(allUsedIds);
+
+    const scheduleMap = new Map(rangeData.map((r) => [r.date, r.player_id]));
+
+    // Track IDs used by suggestions so we don't suggest the same player twice
+    const suggestionUsed = new Set(allUsedIds);
+
+    const dayStates: DayState[] = dates.map((date) => {
+      const assignedId = scheduleMap.get(date);
+      const assignedPlayer = assignedId
+        ? SEED_PLAYERS.find((p) => p.id === assignedId) ?? null
+        : null;
+
+      let suggestion: Player | null = null;
+      if (!assignedPlayer) {
+        suggestion = (() => {
+          const avail = SEED_PLAYERS.filter((p) => !suggestionUsed.has(p.id));
+          if (avail.length === 0) return null;
+          const pick = avail[Math.floor(Math.random() * avail.length)];
+          suggestionUsed.add(pick.id);
+          return pick;
+        })();
+      }
+
+      return { date, assignedPlayer, suggestion };
+    });
+
+    setDays(dayStates);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    // Load initial schedule data — setState inside loadSchedule is expected
+    loadSchedule(); // eslint-disable-line react-hooks/set-state-in-effect
+  }, [loadSchedule]);
+
+  const handleApprove = useCallback(async (date: string, player: Player) => {
+    const ok = await upsertSchedule(date, player.id);
+    if (ok) {
+      setDays((prev) =>
+        prev.map((d) =>
+          d.date === date ? { ...d, assignedPlayer: player, suggestion: null } : d,
+        ),
+      );
+      setUsedPlayerIds((prev) => new Set([...prev, player.id]));
+    }
+  }, []);
+
+  const handleReject = useCallback(
+    (date: string) => {
+      setDays((prev) =>
+        prev.map((d) => {
+          if (d.date !== date || d.assignedPlayer) return d;
+          // Pick a new suggestion, excluding already-used and current suggestions for other days
+          const allSuggested = new Set(
+            prev.filter((x) => x.suggestion && x.date !== date).map((x) => x.suggestion!.id),
+          );
+          const exclude = new Set([...usedPlayerIds, ...allSuggested]);
+          if (d.suggestion) exclude.add(d.suggestion.id);
+          const newSuggestion = getRandomUnused(exclude);
+          return { ...d, suggestion: newSuggestion };
+        }),
+      );
+    },
+    [usedPlayerIds, getRandomUnused],
+  );
+
+  const handleClear = useCallback(async (date: string) => {
+    const ok = await deleteSchedule(date);
+    if (ok) {
+      setDays((prev) =>
+        prev.map((d) => {
+          if (d.date !== date) return d;
+          // Generate a new suggestion for the cleared date
+          return { ...d, assignedPlayer: null, suggestion: null };
+        }),
+      );
+      // Reload to get fresh suggestions
+      await loadSchedule();
+    }
+  }, [loadSchedule]);
+
+  const toggleExpand = useCallback((date: string) => {
+    setExpandedDate((prev) => (prev === date ? null : date));
+  }, []);
+
+  if (loading) {
+    return <p className="text-gray-400 text-center py-8">Loading schedule...</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold mb-4">
+        Daily Schedule
+        <span className="text-gray-400 text-sm font-normal ml-2">
+          {SEED_PLAYERS.length - usedPlayerIds.size} players remaining
+        </span>
+      </h2>
+
+      {days.map((day) => {
+        const isPast = day.date < today;
+        const isToday = day.date === today;
+        const player = day.assignedPlayer ?? day.suggestion;
+        const isSuggestion = !day.assignedPlayer && !!day.suggestion;
+        const isExpanded = expandedDate === day.date;
+
+        return (
+          <div
+            key={day.date}
+            className={`rounded-lg border ${
+              isToday
+                ? "border-green-600 bg-gray-800"
+                : isPast
+                  ? "border-gray-700 bg-gray-800/50 opacity-60"
+                  : "border-gray-700 bg-gray-800"
+            }`}
+          >
+            {/* Day row */}
+            <div className="flex items-center gap-3 px-4 py-3">
+              {/* Date */}
+              <div className="w-32 shrink-0">
+                <div className="text-sm font-medium text-white">
+                  {formatDate(day.date)}
+                  {isToday && <span className="text-green-400 ml-1">(today)</span>}
+                </div>
+                <div className="text-xs text-gray-500">{day.date}</div>
+              </div>
+
+              {/* Player info */}
+              {player ? (
+                <button
+                  onClick={() => toggleExpand(day.date)}
+                  className="flex items-center gap-3 flex-1 text-left hover:bg-gray-700/50 rounded-lg px-2 py-1 -mx-2 -my-1 transition-colors"
+                >
+                  {player.thumbnail && (
+                    <img
+                      src={player.thumbnail}
+                      alt=""
+                      className="w-8 h-8 rounded-full object-cover bg-gray-700"
+                    />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <span className={`font-medium ${isSuggestion ? "text-yellow-300" : "text-white"}`}>
+                      {player.name}
+                    </span>
+                    {isSuggestion && (
+                      <span className="text-yellow-500/70 text-xs ml-2">suggestion</span>
+                    )}
+                    <div className="text-xs text-gray-400">{player.nationality}</div>
+                  </div>
+                  <svg
+                    className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+              ) : (
+                <span className="flex-1 text-gray-500 text-sm italic">No players available</span>
+              )}
+
+              {/* Actions */}
+              <div className="flex gap-2 shrink-0">
+                {isSuggestion && !isPast && (
+                  <>
+                    <button
+                      onClick={() => handleApprove(day.date, day.suggestion!)}
+                      className="px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => handleReject(day.date)}
+                      className="px-3 py-1.5 bg-gray-600 hover:bg-gray-500 text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                      Skip
+                    </button>
+                  </>
+                )}
+                {day.assignedPlayer && !isPast && !isToday && (
+                  <button
+                    onClick={() => handleClear(day.date)}
+                    className="px-3 py-1.5 bg-red-600/20 hover:bg-red-600/40 text-red-400 text-sm font-medium rounded-lg transition-colors"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Expanded: club history */}
+            {isExpanded && player && (
+              <div className="border-t border-gray-700 px-4 py-3">
+                <PlayerClubList playerId={player.id} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/Admin/constants.ts
+++ b/src/pages/Admin/constants.ts
@@ -1,0 +1,2 @@
+export const ADMIN_SESSION_KEY = "football-nerdle-admin";
+export const SCHEDULE_DAYS_AHEAD = 14;

--- a/src/pages/Admin/index.tsx
+++ b/src/pages/Admin/index.tsx
@@ -1,0 +1,78 @@
+import { useState, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ADMIN_SESSION_KEY } from "./constants";
+import ScheduleManager from "./ScheduleManager";
+
+const PASSPHRASE = import.meta.env.VITE_ADMIN_PASSPHRASE ?? "";
+
+function PassphraseGate({ onAuth }: { onAuth: () => void }) {
+  const [input, setInput] = useState("");
+  const [error, setError] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (input === PASSPHRASE) {
+      sessionStorage.setItem(ADMIN_SESSION_KEY, "1");
+      onAuth();
+    } else {
+      setError(true);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="bg-gray-800 rounded-xl p-8 w-full max-w-sm">
+        <h1 className="text-white text-xl font-bold mb-4">Admin Access</h1>
+        <input
+          type="password"
+          value={input}
+          onChange={(e) => { setInput(e.target.value); setError(false); }}
+          placeholder="Passphrase"
+          className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-green-500 mb-3"
+          autoFocus
+        />
+        {error && <p className="text-red-400 text-sm mb-3">Incorrect passphrase</p>}
+        <button
+          type="submit"
+          className="w-full py-3 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg transition-colors"
+        >
+          Enter
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function Admin() {
+  const [authed, setAuthed] = useState(
+    () => sessionStorage.getItem(ADMIN_SESSION_KEY) === "1" && PASSPHRASE !== "",
+  );
+
+  const handleAuth = useCallback(() => setAuthed(true), []);
+
+  if (!PASSPHRASE) {
+    return (
+      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
+        <p className="text-gray-400">VITE_ADMIN_PASSPHRASE not configured.</p>
+      </div>
+    );
+  }
+
+  if (!authed) {
+    return <PassphraseGate onAuth={handleAuth} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="max-w-3xl mx-auto p-4">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold">Admin</h1>
+          <Link to="/" className="text-gray-400 hover:text-white text-sm transition-colors">
+            ← Back to Home
+          </Link>
+        </div>
+        <ScheduleManager />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Admin/types.ts
+++ b/src/pages/Admin/types.ts
@@ -1,0 +1,18 @@
+import type { Player } from "../../types";
+
+export interface ScheduleEntry {
+  date: string;
+  player: Player | null;
+  isLocked: boolean; // true for past dates or approved future dates
+}
+
+export interface AdminClubRow {
+  id: number;
+  club_id: string;
+  club_name: string;
+  badge: string;
+  year_joined: string;
+  year_departed: string;
+  is_hidden: boolean;
+  sort_order: number | null;
+}

--- a/supabase/migrations/006_admin_features.sql
+++ b/supabase/migrations/006_admin_features.sql
@@ -1,0 +1,33 @@
+-- Admin features: schedule editing + club visibility control + crest storage
+
+-- 1. Allow modifying daily_schedule entries (for curating upcoming puzzles)
+CREATE POLICY "Anyone can update daily_schedule"
+  ON daily_schedule FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete daily_schedule"
+  ON daily_schedule FOR DELETE USING (true);
+
+-- 2. Add hidden flag and sort order to player_clubs
+ALTER TABLE player_clubs
+  ADD COLUMN IF NOT EXISTS is_hidden BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE player_clubs
+  ADD COLUMN IF NOT EXISTS sort_order INTEGER;
+
+-- 3. Create storage bucket for uploaded club crests
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('club-crests', 'club-crests', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow public read access to club crests
+CREATE POLICY "Public read access for club crests"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'club-crests');
+
+-- Allow anyone to upload club crests (admin passphrase is enforced client-side)
+CREATE POLICY "Anyone can upload club crests"
+  ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'club-crests');
+
+-- Allow anyone to overwrite club crests
+CREATE POLICY "Anyone can update club crests"
+  ON storage.objects FOR UPDATE
+  USING (bucket_id = 'club-crests');


### PR DESCRIPTION
## Summary
- Passphrase-gated admin page at `/#/admin` for curating upcoming Guess the Player daily puzzles
- Suggest/approve/reject players for each upcoming date, with inline club history preview
- Hide/show clubs from player histories (e.g. youth teams), reorder clubs, edit club names inline
- Drag-and-drop crest upload to Supabase Storage for missing club badges
- Lazy-loaded admin chunk (4.3 KB gzip) — no impact on main bundle

## Migration
Already applied to both dev and production Supabase:
- `is_hidden` and `sort_order` columns on `player_clubs`
- UPDATE/DELETE policies on `daily_schedule`
- `club-crests` storage bucket with public read access

## Test plan
- [ ] Navigate to `/#/admin`, verify passphrase gate
- [ ] Approve a suggested player, refresh, confirm it persists
- [ ] Reject a suggestion, verify new player appears
- [ ] Expand a player, toggle hide on a club, verify it disappears in the game
- [ ] Reorder clubs with arrows, verify order persists
- [ ] Click club name to edit, verify update
- [ ] Drag image onto a missing badge, verify upload and display
- [ ] Verify existing game modes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)