### PR TITLE
fix: use service role key for admin write operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_SUPABASE_ANON_KEY=your-anon-key-here
 
 # Admin interface passphrase (required for /#/admin access)
 VITE_ADMIN_PASSPHRASE=your-admin-passphrase-here
+
+# Supabase service role key (local admin only — never deploy this)
+# VITE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ skills-lock.json
 # Playwright
 test-results/
 playwright-report/
+
+# Supabase
+supabase/.temp/

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,22 +1,29 @@
-import { supabase } from "./supabaseClient";
+import { supabase, supabaseAdmin } from "./supabaseClient";
 import type { AdminClubRow } from "../pages/Admin/types";
+
+// Write operations use the admin client (service role key, bypasses RLS).
+// Read operations use the regular client (anon/publishable key).
 
 // --- Schedule operations ---
 
 export async function upsertSchedule(date: string, playerId: string): Promise<boolean> {
-  if (!supabase) return false;
-  const { error } = await supabase
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
     .from("daily_schedule")
     .upsert({ date, player_id: playerId }, { onConflict: "date" });
+  if (error) console.error("upsertSchedule failed:", error);
   return !error;
 }
 
 export async function deleteSchedule(date: string): Promise<boolean> {
-  if (!supabase) return false;
-  const { error } = await supabase
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
     .from("daily_schedule")
     .delete()
     .eq("date", date);
+  if (error) console.error("deleteSchedule failed:", error);
   return !error;
 }
 
@@ -69,11 +76,13 @@ export async function updatePlayerClubHidden(
   playerClubId: number,
   isHidden: boolean,
 ): Promise<boolean> {
-  if (!supabase) return false;
-  const { error } = await supabase
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
     .from("player_clubs")
     .update({ is_hidden: isHidden })
     .eq("id", playerClubId);
+  if (error) console.error("updatePlayerClubHidden failed:", error);
   return !error;
 }
 
@@ -82,13 +91,17 @@ export async function updatePlayerClubHidden(
 export async function updateClubSortOrders(
   updates: { id: number; sort_order: number }[],
 ): Promise<boolean> {
-  if (!supabase) return false;
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
   for (const { id, sort_order } of updates) {
-    const { error } = await supabase
+    const { error } = await client
       .from("player_clubs")
       .update({ sort_order })
       .eq("id", id);
-    if (error) return false;
+    if (error) {
+      console.error("updateClubSortOrders failed:", error);
+      return false;
+    }
   }
   return true;
 }
@@ -96,11 +109,13 @@ export async function updateClubSortOrders(
 // --- Club name operations ---
 
 export async function updateClubName(clubId: string, name: string): Promise<boolean> {
-  if (!supabase) return false;
-  const { error } = await supabase
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
     .from("clubs")
     .update({ name })
     .eq("id", clubId);
+  if (error) console.error("updateClubName failed:", error);
   return !error;
 }
 
@@ -117,35 +132,42 @@ export async function searchClubs(query: string): Promise<{ id: string; name: st
 }
 
 export async function uploadClubCrest(clubId: string, file: File): Promise<string | null> {
-  if (!supabase) return null;
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return null;
   const ext = file.name.split(".").pop() ?? "png";
   const path = `${clubId}.${ext}`;
 
-  const { error: uploadError } = await supabase.storage
+  const { error: uploadError } = await client.storage
     .from("club-crests")
     .upload(path, file, { upsert: true });
-  if (uploadError) return null;
+  if (uploadError) {
+    console.error("uploadClubCrest upload failed:", uploadError);
+    return null;
+  }
 
-  const { data: urlData } = supabase.storage
+  const { data: urlData } = client.storage
     .from("club-crests")
     .getPublicUrl(path);
 
   const publicUrl = urlData.publicUrl;
 
   // Update the club record with the new badge URL
-  await supabase
+  const { error: updateError } = await client
     .from("clubs")
     .update({ badge: publicUrl })
     .eq("id", clubId);
+  if (updateError) console.error("uploadClubCrest update failed:", updateError);
 
   return publicUrl;
 }
 
 export async function updateClubBadge(clubId: string, badgeUrl: string): Promise<boolean> {
-  if (!supabase) return false;
-  const { error } = await supabase
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
     .from("clubs")
     .update({ badge: badgeUrl })
     .eq("id", clubId);
+  if (error) console.error("updateClubBadge failed:", error);
   return !error;
 }

--- a/src/api/supabaseClient.ts
+++ b/src/api/supabaseClient.ts
@@ -13,3 +13,10 @@ export const supabase =
   supabaseUrl && supabaseAnonKey
     ? createClient(supabaseUrl, supabaseAnonKey)
     : null;
+
+// Admin client uses the service role key to bypass RLS (local admin only)
+const serviceRoleKey = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
+export const supabaseAdmin =
+  supabaseUrl && serviceRoleKey
+    ? createClient(supabaseUrl, serviceRoleKey)
+    : null;


### PR DESCRIPTION
## Summary
- Production RLS policies are read-only for the anon/publishable key, causing admin writes (schedule, clubs, crests) to silently fail
- Added a `supabaseAdmin` client using the service role key (`VITE_SUPABASE_SERVICE_ROLE_KEY`) that bypasses RLS for write operations
- The service role key is only set locally via `.env.local` and is never deployed
- Added error logging to all admin write operations

## Test plan
- [ ] Set `VITE_SUPABASE_SERVICE_ROLE_KEY` in `.env.local` with the production service role key
- [ ] Verify crest uploads persist after page reload
- [ ] Verify schedule approvals persist after page reload
- [ ] Verify club name edits and reordering persist
- [ ] Verify the deployed site still works without the service role key (read-only fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)