### PR TITLE
feat: add youth team and loan flags to player club history

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -47,7 +47,7 @@ export async function getPlayerClubsAdmin(playerId: string): Promise<AdminClubRo
   if (!supabase) return [];
   const { data } = await supabase
     .from("player_clubs")
-    .select("id, club_id, year_joined, year_departed, is_hidden, sort_order, clubs(name, badge)")
+    .select("id, club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(name, badge)")
     .eq("player_id", playerId)
     .order("sort_order", { ascending: true, nullsFirst: false })
     .order("year_joined", { ascending: true });
@@ -58,6 +58,8 @@ export async function getPlayerClubsAdmin(playerId: string): Promise<AdminClubRo
     year_joined: string;
     year_departed: string;
     is_hidden: boolean;
+    is_youth_team: boolean;
+    is_loan: boolean;
     sort_order: number | null;
     clubs: { name: string; badge: string } | null;
   }>).map((row) => ({
@@ -68,6 +70,8 @@ export async function getPlayerClubsAdmin(playerId: string): Promise<AdminClubRo
     year_joined: row.year_joined,
     year_departed: row.year_departed,
     is_hidden: row.is_hidden,
+    is_youth_team: row.is_youth_team,
+    is_loan: row.is_loan,
     sort_order: row.sort_order,
   }));
 }
@@ -83,6 +87,34 @@ export async function updatePlayerClubHidden(
     .update({ is_hidden: isHidden })
     .eq("id", playerClubId);
   if (error) console.error("updatePlayerClubHidden failed:", error);
+  return !error;
+}
+
+export async function updatePlayerClubYouthTeam(
+  playerClubId: number,
+  isYouthTeam: boolean,
+): Promise<boolean> {
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
+    .from("player_clubs")
+    .update({ is_youth_team: isYouthTeam })
+    .eq("id", playerClubId);
+  if (error) console.error("updatePlayerClubYouthTeam failed:", error);
+  return !error;
+}
+
+export async function updatePlayerClubLoan(
+  playerClubId: number,
+  isLoan: boolean,
+): Promise<boolean> {
+  const client = supabaseAdmin ?? supabase;
+  if (!client) return false;
+  const { error } = await client
+    .from("player_clubs")
+    .update({ is_loan: isLoan })
+    .eq("id", playerClubId);
+  if (error) console.error("updatePlayerClubLoan failed:", error);
   return !error;
 }
 

--- a/src/api/playerCache.ts
+++ b/src/api/playerCache.ts
@@ -65,6 +65,8 @@ interface PlayerClubRow {
   year_joined: string;
   year_departed: string;
   is_hidden?: boolean;
+  is_youth_team?: boolean;
+  is_loan?: boolean;
   sort_order?: number | null;
   clubs: { id: string; name: string; badge: string } | null;
 }
@@ -81,7 +83,7 @@ interface PlayerRow {
   countries: { name: string } | null;
 }
 
-const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, countries(name), player_clubs(club_id, year_joined, year_departed, is_hidden, sort_order, clubs(id, name, badge))";
+const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, countries(name), player_clubs(club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(id, name, badge))";
 
 let countryNamesCache: Set<string> | null = null;
 
@@ -155,6 +157,7 @@ async function buildPlayerWithTeams(row: PlayerRow): Promise<PlayerWithTeams> {
   const filtered = row.player_clubs
     .filter((pc) => pc.clubs)
     .filter((pc) => !pc.is_hidden)
+    .filter((pc) => !pc.is_youth_team)
     .filter((pc) => !isNationalTeam(pc.clubs!.name, countryNames));
 
   // Use explicit sort_order if any club has one set, otherwise fall back to year-based sort
@@ -170,6 +173,7 @@ async function buildPlayerWithTeams(row: PlayerRow): Promise<PlayerWithTeams> {
     yearJoined: pc.year_joined,
     yearDeparted: pc.year_departed,
     badge: pc.clubs!.badge,
+    isLoan: pc.is_loan || undefined,
   }));
 
   const orderedTeams = hasCustomOrder

--- a/src/components/PlayerCard/index.tsx
+++ b/src/components/PlayerCard/index.tsx
@@ -98,7 +98,9 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
             {clubs.map((club, i) => (
               <div key={`${club.teamId}-${i}`} className="flex items-center">
                 {i > 0 && <span className="text-gray-500 text-lg mx-1">→</span>}
-                <BadgeImg src={club.badge} alt={club.teamName} size="lg" />
+                <div className={`rounded-lg p-1 border ${club.isLoan ? "border-dashed border-gray-500" : "border-transparent"}`}>
+                  <BadgeImg src={club.badge} alt={club.teamName} size="lg" />
+                </div>
               </div>
             ))}
           </div>
@@ -107,9 +109,12 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
             {clubs.map((club, i) => (
               <div key={`${club.teamId}-${i}`}>
                 {i > 0 && <div className="text-gray-500 text-center text-sm">↓</div>}
-                <div className="flex items-center gap-3 bg-gray-700 rounded-lg px-4 py-2">
+                <div className={`flex items-center gap-3 rounded-lg px-4 py-2 border ${club.isLoan ? "bg-gray-700/60 border-dashed border-gray-500" : "bg-gray-700 border-transparent"}`}>
                   <BadgeImg src={club.badge} alt={club.teamName} size="sm" />
                   <span className="font-medium text-sm">{club.teamName}</span>
+                  {club.isLoan && (
+                    <span className="text-gray-400 text-xs px-1.5 py-0.5 rounded-full bg-gray-600/50">loan</span>
+                  )}
                   <span className="bg-gray-800 text-gray-300 text-xs px-2.5 py-1 rounded-full ml-auto whitespace-nowrap">
                     {club.yearJoined}{club.yearDeparted ? ` – ${club.yearDeparted}` : " – present"}
                   </span>

--- a/src/components/PlayerCard/types.ts
+++ b/src/components/PlayerCard/types.ts
@@ -7,6 +7,7 @@ export interface MergedClub {
   yearJoined: string;
   yearDeparted: string;
   badge: string;
+  isLoan?: boolean;
   stints: FormerTeam[];
 }
 

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from "react";
 import {
   getPlayerClubsAdmin,
   updatePlayerClubHidden,
+  updatePlayerClubYouthTeam,
+  updatePlayerClubLoan,
   updateClubSortOrders,
   updateClubName,
 } from "../../api/adminApi";
@@ -35,6 +37,26 @@ export default function PlayerClubList({ playerId }: Props) {
     if (ok) {
       setClubs((prev) =>
         prev.map((c) => (c.id === club.id ? { ...c, is_hidden: newHidden } : c)),
+      );
+    }
+  }
+
+  async function toggleYouthTeam(club: AdminClubRow) {
+    const newValue = !club.is_youth_team;
+    const ok = await updatePlayerClubYouthTeam(club.id, newValue);
+    if (ok) {
+      setClubs((prev) =>
+        prev.map((c) => (c.id === club.id ? { ...c, is_youth_team: newValue } : c)),
+      );
+    }
+  }
+
+  async function toggleLoan(club: AdminClubRow) {
+    const newValue = !club.is_loan;
+    const ok = await updatePlayerClubLoan(club.id, newValue);
+    if (ok) {
+      setClubs((prev) =>
+        prev.map((c) => (c.id === club.id ? { ...c, is_loan: newValue } : c)),
       );
     }
   }
@@ -106,7 +128,7 @@ export default function PlayerClubList({ playerId }: Props) {
         <div
           key={club.id}
           className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-opacity ${
-            club.is_hidden ? "opacity-40" : ""
+            club.is_hidden || club.is_youth_team ? "opacity-40" : ""
           }`}
         >
           {/* Reorder buttons */}
@@ -167,6 +189,28 @@ export default function PlayerClubList({ playerId }: Props) {
             <div className="text-xs text-gray-500">
               {club.year_joined || "?"} – {club.year_departed || "present"}
             </div>
+          </div>
+
+          {/* Flags */}
+          <div className="flex items-center gap-3 shrink-0">
+            <label className="flex items-center gap-1 cursor-pointer" title="Youth team (hidden in game)">
+              <input
+                type="checkbox"
+                checked={club.is_youth_team}
+                onChange={() => toggleYouthTeam(club)}
+                className="accent-yellow-500 w-3.5 h-3.5"
+              />
+              <span className={`text-xs ${club.is_youth_team ? "text-yellow-400" : "text-gray-500"}`}>Youth</span>
+            </label>
+            <label className="flex items-center gap-1 cursor-pointer" title="Loan spell">
+              <input
+                type="checkbox"
+                checked={club.is_loan}
+                onChange={() => toggleLoan(club)}
+                className="accent-blue-500 w-3.5 h-3.5"
+              />
+              <span className={`text-xs ${club.is_loan ? "text-blue-400" : "text-gray-500"}`}>Loan</span>
+            </label>
           </div>
 
           {/* Hide/show toggle */}

--- a/src/pages/Admin/types.ts
+++ b/src/pages/Admin/types.ts
@@ -14,5 +14,7 @@ export interface AdminClubRow {
   year_joined: string;
   year_departed: string;
   is_hidden: boolean;
+  is_youth_team: boolean;
+  is_loan: boolean;
   sort_order: number | null;
 }

--- a/src/pages/GuessThePlayer/helpers.ts
+++ b/src/pages/GuessThePlayer/helpers.ts
@@ -87,6 +87,7 @@ export function mergeConsecutiveClubs(clubs: FormerTeam[]): MergedClub[] {
         yearJoined: club.yearJoined,
         yearDeparted: club.yearDeparted,
         badge: club.badge,
+        isLoan: club.isLoan,
         stints: [club],
       });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface FormerTeam {
   yearJoined: string;
   yearDeparted: string;
   badge: string;
+  isLoan?: boolean;
 }
 
 export interface PlayerWithTeams extends Player {

--- a/supabase/migrations/007_youth_and_loan_flags.sql
+++ b/supabase/migrations/007_youth_and_loan_flags.sql
@@ -1,0 +1,5 @@
+-- Add youth team and loan flags to player_clubs for admin curation
+ALTER TABLE player_clubs
+  ADD COLUMN IF NOT EXISTS is_youth_team BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE player_clubs
+  ADD COLUMN IF NOT EXISTS is_loan BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Add `is_youth_team` and `is_loan` boolean columns to `player_clubs` (migration 007)
- Youth teams are automatically filtered out in the game (same as `is_hidden`), with checkboxes in the admin to toggle
- Loan spells shown with dashed border in both hard mode and normal mode, plus a "loan" pill in normal mode
- Admin club list shows Youth and Loan checkboxes next to each club entry

## Test plan
- [ ] Apply migration 007 to target database
- [ ] Toggle youth team checkbox in admin — verify club is dimmed and hidden in game
- [ ] Toggle loan checkbox in admin — verify dashed border and "loan" pill appear in Guess the Player (normal mode)
- [ ] Verify dashed border appears around badge in hard mode for loan clubs
- [ ] Verify non-loan clubs have consistent sizing (transparent border)

🤖 Generated with [Claude Code](https://claude.com/claude-code)