### PR TITLE
feat: replace admin passphrase with Supabase Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,5 @@ VITE_SUPABASE_ANON_KEY=your-anon-key-here
 # Or if Supabase provides a publishable key instead:
 # VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key-here
 
-# Admin interface passphrase (required for /#/admin access)
-VITE_ADMIN_PASSPHRASE=your-admin-passphrase-here
-
-# Supabase service role key (local admin only — never deploy this)
-# VITE_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+# Service role key for import scripts only (never expose to browser)
+# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here

--- a/scripts/import-transfermarkt.ts
+++ b/scripts/import-transfermarkt.ts
@@ -16,7 +16,10 @@ import { Readable } from "stream";
 import { createInterface } from "readline";
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
   console.error("Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY");

--- a/scripts/seed-players.ts
+++ b/scripts/seed-players.ts
@@ -37,7 +37,10 @@ const TOP_CLUBS = [
 ];
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 const sportsdbKey = process.env.VITE_SPORTSDB_API_KEY || "3";
 
 if (!supabaseUrl || !supabaseKey) {

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,15 +1,11 @@
-import { supabase, supabaseAdmin } from "./supabaseClient";
+import { supabase } from "./supabaseClient";
 import type { AdminClubRow } from "../pages/Admin/types";
-
-// Write operations use the admin client (service role key, bypasses RLS).
-// Read operations use the regular client (anon/publishable key).
 
 // --- Schedule operations ---
 
 export async function upsertSchedule(date: string, playerId: string): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("daily_schedule")
     .upsert({ date, player_id: playerId }, { onConflict: "date" });
   if (error) console.error("upsertSchedule failed:", error);
@@ -17,9 +13,8 @@ export async function upsertSchedule(date: string, playerId: string): Promise<bo
 }
 
 export async function deleteSchedule(date: string): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("daily_schedule")
     .delete()
     .eq("date", date);
@@ -80,9 +75,8 @@ export async function updatePlayerClubHidden(
   playerClubId: number,
   isHidden: boolean,
 ): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("player_clubs")
     .update({ is_hidden: isHidden })
     .eq("id", playerClubId);
@@ -123,10 +117,9 @@ export async function updatePlayerClubLoan(
 export async function updateClubSortOrders(
   updates: { id: number; sort_order: number }[],
 ): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
+  if (!supabase) return false;
   for (const { id, sort_order } of updates) {
-    const { error } = await client
+    const { error } = await supabase
       .from("player_clubs")
       .update({ sort_order })
       .eq("id", id);
@@ -141,9 +134,8 @@ export async function updateClubSortOrders(
 // --- Club name operations ---
 
 export async function updateClubName(clubId: string, name: string): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("clubs")
     .update({ name })
     .eq("id", clubId);
@@ -164,12 +156,11 @@ export async function searchClubs(query: string): Promise<{ id: string; name: st
 }
 
 export async function uploadClubCrest(clubId: string, file: File): Promise<string | null> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return null;
+  if (!supabase) return null;
   const ext = file.name.split(".").pop() ?? "png";
   const path = `${clubId}.${ext}`;
 
-  const { error: uploadError } = await client.storage
+  const { error: uploadError } = await supabase.storage
     .from("club-crests")
     .upload(path, file, { upsert: true });
   if (uploadError) {
@@ -177,14 +168,14 @@ export async function uploadClubCrest(clubId: string, file: File): Promise<strin
     return null;
   }
 
-  const { data: urlData } = client.storage
+  const { data: urlData } = supabase.storage
     .from("club-crests")
     .getPublicUrl(path);
 
   const publicUrl = urlData.publicUrl;
 
   // Update the club record with the new badge URL
-  const { error: updateError } = await client
+  const { error: updateError } = await supabase
     .from("clubs")
     .update({ badge: publicUrl })
     .eq("id", clubId);
@@ -194,9 +185,8 @@ export async function uploadClubCrest(clubId: string, file: File): Promise<strin
 }
 
 export async function updateClubBadge(clubId: string, badgeUrl: string): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("clubs")
     .update({ badge: badgeUrl })
     .eq("id", clubId);

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -88,9 +88,8 @@ export async function updatePlayerClubYouthTeam(
   playerClubId: number,
   isYouthTeam: boolean,
 ): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("player_clubs")
     .update({ is_youth_team: isYouthTeam })
     .eq("id", playerClubId);
@@ -102,9 +101,8 @@ export async function updatePlayerClubLoan(
   playerClubId: number,
   isLoan: boolean,
 ): Promise<boolean> {
-  const client = supabaseAdmin ?? supabase;
-  if (!client) return false;
-  const { error } = await client
+  if (!supabase) return false;
+  const { error } = await supabase
     .from("player_clubs")
     .update({ is_loan: isLoan })
     .eq("id", playerClubId);

--- a/src/api/supabaseClient.ts
+++ b/src/api/supabaseClient.ts
@@ -13,10 +13,3 @@ export const supabase =
   supabaseUrl && supabaseAnonKey
     ? createClient(supabaseUrl, supabaseAnonKey)
     : null;
-
-// Admin client uses the service role key to bypass RLS (local admin only)
-const serviceRoleKey = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
-export const supabaseAdmin =
-  supabaseUrl && serviceRoleKey
-    ? createClient(supabaseUrl, serviceRoleKey)
-    : null;

--- a/src/api/useAdminAuth.ts
+++ b/src/api/useAdminAuth.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "./supabaseClient";
+import type { Session } from "@supabase/supabase-js";
+
+interface UseAdminAuth {
+  session: Session | null;
+  loading: boolean;
+  error: string | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export function useAdminAuth(): UseAdminAuth {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+
+    supabase.auth.getSession().then(({ data: { session: s } }) => {
+      setSession(s);
+      setLoading(false);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, s) => setSession(s),
+    );
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    if (!supabase) return;
+    setError(null);
+    const { error: err } = await supabase.auth.signInWithPassword({ email, password });
+    if (err) setError(err.message);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!supabase) return;
+    await supabase.auth.signOut();
+    setSession(null);
+  }, []);
+
+  return { session, loading, error, signIn, signOut };
+}

--- a/src/pages/Admin/constants.ts
+++ b/src/pages/Admin/constants.ts
@@ -1,2 +1,1 @@
-export const ADMIN_SESSION_KEY = "football-nerdle-admin";
 export const SCHEDULE_DAYS_AHEAD = 14;

--- a/src/pages/Admin/index.tsx
+++ b/src/pages/Admin/index.tsx
@@ -1,42 +1,42 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { ADMIN_SESSION_KEY } from "./constants";
+import { useAdminAuth } from "../../api/useAdminAuth";
 import ScheduleManager from "./ScheduleManager";
 
-const PASSPHRASE = import.meta.env.VITE_ADMIN_PASSPHRASE ?? "";
-
-function PassphraseGate({ onAuth }: { onAuth: () => void }) {
-  const [input, setInput] = useState("");
-  const [error, setError] = useState(false);
+function SignInForm({ onSignIn, error }: { onSignIn: (email: string, password: string) => void; error: string | null }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (input === PASSPHRASE) {
-      sessionStorage.setItem(ADMIN_SESSION_KEY, "1");
-      onAuth();
-    } else {
-      setError(true);
-    }
+    onSignIn(email, password);
   }
 
   return (
     <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="bg-gray-800 rounded-xl p-8 w-full max-w-sm">
-        <h1 className="text-white text-xl font-bold mb-4">Admin Access</h1>
+        <h1 className="text-white text-xl font-bold mb-4">Admin Sign In</h1>
         <input
-          type="password"
-          value={input}
-          onChange={(e) => { setInput(e.target.value); setError(false); }}
-          placeholder="Passphrase"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
           className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-green-500 mb-3"
           autoFocus
         />
-        {error && <p className="text-red-400 text-sm mb-3">Incorrect passphrase</p>}
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-green-500 mb-3"
+        />
+        {error && <p className="text-red-400 text-sm mb-3">{error}</p>}
         <button
           type="submit"
           className="w-full py-3 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg transition-colors"
         >
-          Enter
+          Sign In
         </button>
       </form>
     </div>
@@ -44,22 +44,18 @@ function PassphraseGate({ onAuth }: { onAuth: () => void }) {
 }
 
 export default function Admin() {
-  const [authed, setAuthed] = useState(
-    () => sessionStorage.getItem(ADMIN_SESSION_KEY) === "1" && PASSPHRASE !== "",
-  );
+  const { session, loading, error, signIn, signOut } = useAdminAuth();
 
-  const handleAuth = useCallback(() => setAuthed(true), []);
-
-  if (!PASSPHRASE) {
+  if (loading) {
     return (
       <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <p className="text-gray-400">VITE_ADMIN_PASSPHRASE not configured.</p>
+        <p className="text-gray-400">Loading...</p>
       </div>
     );
   }
 
-  if (!authed) {
-    return <PassphraseGate onAuth={handleAuth} />;
+  if (!session) {
+    return <SignInForm onSignIn={signIn} error={error} />;
   }
 
   return (
@@ -67,9 +63,15 @@ export default function Admin() {
       <div className="max-w-3xl mx-auto p-4">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold">Admin</h1>
-          <Link to="/" className="text-gray-400 hover:text-white text-sm transition-colors">
-            ← Back to Home
-          </Link>
+          <div className="flex items-center gap-4">
+            <span className="text-gray-500 text-sm">{session.user.email}</span>
+            <button onClick={signOut} className="text-gray-400 hover:text-white text-sm transition-colors">
+              Sign Out
+            </button>
+            <Link to="/" className="text-gray-400 hover:text-white text-sm transition-colors">
+              ← Home
+            </Link>
+          </div>
         </div>
         <ScheduleManager />
       </div>

--- a/supabase/migrations/008_admin_auth.sql
+++ b/supabase/migrations/008_admin_auth.sql
@@ -17,7 +17,7 @@ CREATE POLICY "Only admins can read admin_users"
   );
 
 -- Seed admin user
-INSERT INTO admin_users (email) VALUES ('martinm@pm.me');
+INSERT INTO admin_users (email) VALUES ('martinsadu@pm.me');
 
 -- 2. Helper function to check if the current user is an admin
 CREATE OR REPLACE FUNCTION is_admin()

--- a/supabase/migrations/008_admin_auth.sql
+++ b/supabase/migrations/008_admin_auth.sql
@@ -1,0 +1,83 @@
+-- Proper admin authentication via Supabase Auth
+-- Replaces client-side passphrase + service role key with RLS-based authorization
+
+-- 1. Admin users table (hardcoded email allowlist)
+CREATE TABLE admin_users (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE admin_users ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Only admins can read admin_users"
+  ON admin_users FOR SELECT
+  USING (
+    auth.uid() IS NOT NULL
+    AND EXISTS (SELECT 1 FROM admin_users au WHERE au.email = auth.jwt()->>'email')
+  );
+
+-- Seed admin user
+INSERT INTO admin_users (email) VALUES ('martinm@pm.me');
+
+-- 2. Helper function to check if the current user is an admin
+CREATE OR REPLACE FUNCTION is_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM admin_users WHERE email = auth.jwt()->>'email'
+  );
+$$;
+
+-- 3. Tighten RLS on data tables: keep SELECT for anyone, restrict writes to admins
+
+-- clubs
+DROP POLICY IF EXISTS "Anyone can insert clubs" ON clubs;
+DROP POLICY IF EXISTS "Anyone can update clubs" ON clubs;
+CREATE POLICY "Admins can insert clubs" ON clubs FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update clubs" ON clubs FOR UPDATE USING (is_admin());
+
+-- players
+DROP POLICY IF EXISTS "Anyone can insert players" ON players;
+DROP POLICY IF EXISTS "Anyone can update players" ON players;
+CREATE POLICY "Admins can insert players" ON players FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update players" ON players FOR UPDATE USING (is_admin());
+
+-- player_clubs
+DROP POLICY IF EXISTS "Anyone can insert player_clubs" ON player_clubs;
+DROP POLICY IF EXISTS "Anyone can update player_clubs" ON player_clubs;
+CREATE POLICY "Admins can insert player_clubs" ON player_clubs FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update player_clubs" ON player_clubs FOR UPDATE USING (is_admin());
+
+-- countries
+DROP POLICY IF EXISTS "Anyone can insert countries" ON countries;
+DROP POLICY IF EXISTS "Anyone can update countries" ON countries;
+CREATE POLICY "Admins can insert countries" ON countries FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update countries" ON countries FOR UPDATE USING (is_admin());
+
+-- pool_refresh
+DROP POLICY IF EXISTS "Anyone can insert pool_refresh" ON pool_refresh;
+DROP POLICY IF EXISTS "Anyone can update pool_refresh" ON pool_refresh;
+CREATE POLICY "Admins can insert pool_refresh" ON pool_refresh FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update pool_refresh" ON pool_refresh FOR UPDATE USING (is_admin());
+
+-- 4. daily_schedule: keep anon SELECT + INSERT, restrict UPDATE + DELETE to admins
+DROP POLICY IF EXISTS "Anyone can update daily_schedule" ON daily_schedule;
+DROP POLICY IF EXISTS "Anyone can delete daily_schedule" ON daily_schedule;
+CREATE POLICY "Admins can update daily_schedule"
+  ON daily_schedule FOR UPDATE USING (is_admin());
+CREATE POLICY "Admins can delete daily_schedule"
+  ON daily_schedule FOR DELETE USING (is_admin());
+
+-- 5. Storage: restrict club-crests uploads to admins
+DROP POLICY IF EXISTS "Anyone can upload club crests" ON storage.objects;
+DROP POLICY IF EXISTS "Anyone can update club crests" ON storage.objects;
+CREATE POLICY "Admins can upload club crests"
+  ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'club-crests' AND is_admin());
+CREATE POLICY "Admins can update club crests"
+  ON storage.objects FOR UPDATE
+  USING (bucket_id = 'club-crests' AND is_admin());


### PR DESCRIPTION
## Summary
- Replace client-side passphrase gate with Supabase Auth email/password sign-in
- Remove service role key from client-side code — RLS now handles authorization
- Add `admin_users` table with email allowlist and `is_admin()` SQL function
- Tighten RLS: data tables are write-restricted to admins, anonymous read access preserved
- Game functionality unaffected (daily schedule auto-creation, multiplayer rooms)

## Before merging
- [ ] Apply migration 008 to production database (SQL editor in Supabase dashboard)
- [ ] Create Supabase Auth user for `martinm@pm.me` in production project

## Test plan
- [ ] Sign in at `/#/admin` with correct email/password — admin UI loads
- [ ] Wrong credentials — error message shown
- [ ] Page refresh — session persists
- [ ] Sign out — returns to sign-in form
- [ ] All admin operations work (schedule, club edits, crest uploads)
- [ ] Anonymous game still works (daily puzzle, multiplayer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)