### PR TITLE
fix: block access to future archive days

### DIFF
--- a/src/pages/GuessThePlayer/useGuessGame.ts
+++ b/src/pages/GuessThePlayer/useGuessGame.ts
@@ -83,6 +83,11 @@ export function useGuessGame() {
   }, [today]);
 
   const loadArchiveDay = useCallback(async (dayNum: number) => {
+    const todayNum = getDayNumber(today);
+    if (dayNum > todayNum || dayNum < 1) {
+      setState((s) => ({ ...s, status: "idle", error: "This day hasn't happened yet.", isArchive: true, dayNumber: dayNum }));
+      return;
+    }
     setState((s) => ({ ...s, status: "loading", error: null }));
     try {
       const date = getDateForDay(dayNum);


### PR DESCRIPTION
## Summary
- Prevent users from playing unreleased daily puzzles by navigating to future day numbers via URL
- Day numbers less than 1 are also blocked
- Shows "This day hasn't happened yet." error message

## Test plan
- [ ] `/#/guess?day=999` shows error instead of loading a puzzle
- [ ] `/#/guess?day=0` shows error
- [ ] Past days still work normally (e.g. `?day=1`)
- [ ] Today's daily game is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)