### PR TITLE
feat: admin schedule search, past dailies, and full dataset import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ A football (soccer) trivia web app with multiple game modes, deployed to GitHub 
 - **Build**: Vite 8
 - **Styling**: Tailwind CSS 4 (via `@tailwindcss/vite` plugin)
 - **Routing**: React Router DOM 7 (HashRouter for GitHub Pages compatibility)
-- **Backend**: Supabase (Postgres + Realtime) — player data + multiplayer game rooms
-- **Data Source**: [TransferMarkt datasets](https://github.com/dcaribou/transfermarkt-datasets) — imported via scripts
+- **Backend**: Supabase (Postgres + Realtime + Auth) — player data, multiplayer rooms, admin auth
+- **Data Source**: [TransferMarkt datasets](https://github.com/dcaribou/transfermarkt-datasets) — ~47k players imported via scripts
 - **Deployment**: GitHub Pages at `https://spiritsack.github.io/football-nerdle/`
 
 ## Environment Variables
@@ -17,7 +17,8 @@ A football (soccer) trivia web app with multiple game modes, deployed to GitHub 
 | Variable | Purpose |
 |----------|---------|
 | `VITE_SUPABASE_URL` | Supabase project URL |
-| `VITE_SUPABASE_ANON_KEY` | Supabase anonymous/public key (read-only) |
+| `VITE_SUPABASE_ANON_KEY` | Supabase anonymous/public key (or `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY`) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for import scripts only (never in browser) |
 
 ## Commands
 
@@ -27,13 +28,15 @@ A football (soccer) trivia web app with multiple game modes, deployed to GitHub 
 - `npm run preview` — Preview production build
 - `npm test` — Unit tests (Vitest)
 - `npm run test:e2e` — E2E tests (Playwright)
+- `npx tsx scripts/import-transfermarkt.ts` — Import target league players
+- `npx tsx scripts/import-transfermarkt.ts --all` — Import all players from dataset
 
 ## Project Structure
 
 ```
 src/
   main.tsx              — Entry point
-  App.tsx               — Routes: /, /battle, /guess, /guess/archive, /battle/multiplayer
+  App.tsx               — Routes: /, /battle, /guess, /guess/archive, /battle/multiplayer, /admin
   types.ts              — Shared types: Player, FormerTeam, PlayerWithTeams, GameRoom
   constants.ts          — Shared constants (TURN_TIME)
   index.css             — Global styles (Tailwind imports)
@@ -42,6 +45,8 @@ src/
     playerCache.ts      — Player data queries: search, lookup, random selection
     dailySchedule.ts    — Daily player selection (Supabase daily_schedule table)
     multiplayerRoom.ts  — Room CRUD: createRoom, joinRoom, updateTurn, subscribeToRoom
+    adminApi.ts         — Admin write operations: schedule, clubs, crests, player lookup
+    useAdminAuth.ts     — Supabase Auth hook for admin sign-in/sign-out
   pages/
     Home/               — Landing page with game mode selection
       index.tsx
@@ -55,6 +60,11 @@ src/
       useMultiplayerRoom.ts, useMultiplayerGame.ts
       MultiplayerGame/  — In-game component
         index.tsx
+    Admin/              — Admin interface (auth-protected)
+      index.tsx, types.ts, constants.ts
+      ScheduleManager.tsx — Daily schedule curation with search
+      PlayerClubList.tsx  — Club history editor (reorder, hide, loan/youth flags, crests)
+      CrestDropZone.tsx   — Drag-and-drop crest upload
   components/
     PlayerSearch/       — Reusable player autocomplete (searches Supabase)
       index.tsx, types.ts
@@ -63,10 +73,12 @@ src/
   utils/
     gameLogic.ts        — didPlayTogether (pure function), ApiError
     dates.ts            — Shared date formatting (getTodayString)
+    clubNames.ts        — Club name normalization
   data/
     seedPlayers.ts      — 107 seed players for daily puzzle (TransferMarkt IDs)
 scripts/
-  import-transfermarkt.ts — Import players/transfers from TransferMarkt CSVs
+  import-transfermarkt.ts — Import players/transfers from TransferMarkt CSVs (--all for full dataset)
+  seed-players.ts         — Pre-populate players from top clubs
 supabase/
   migrations/           — SQL migration files for Supabase schema
 e2e/                    — Playwright E2E tests
@@ -74,8 +86,9 @@ e2e/                    — Playwright E2E tests
 
 ## Architecture
 
-- **Player data**: All player data lives in Supabase, imported from TransferMarkt datasets. No runtime API calls to external services. Player search queries the Supabase `players` table directly.
-- **Data tables are read-only**: RLS policies only allow SELECT for the anon key. Writes require the service role key (used by import scripts only).
+- **Player data**: All player data lives in Supabase, imported from TransferMarkt datasets (~47k players). No runtime API calls to external services. Player search queries the Supabase `players` table directly.
+- **Admin authentication**: Supabase Auth (email/password) protects the admin interface. An `admin_users` table stores allowed emails. The `is_admin()` SQL function checks the JWT against this table. No service role key in client code.
+- **RLS policies**: Data tables allow SELECT for anyone, INSERT/UPDATE restricted to admin users. `daily_schedule` allows anon INSERT (game auto-creates daily entries). `game_rooms` allows full anon access (multiplayer).
 - **`didPlayTogether`**: Pure function in `utils/gameLogic.ts` — checks if two players overlapped at the same club. No API calls.
 - **Multiplayer**: Supabase Realtime (Postgres Changes) syncs game room state between two clients. The `game_rooms` DB row is the single source of truth. Optimistic locking on `current_turn` prevents race conditions.
 
@@ -83,13 +96,14 @@ e2e/                    — Playwright E2E tests
 
 | Table | Purpose | RLS |
 |-------|---------|-----|
-| `countries` | Country names | Read-only |
-| `clubs` | Club data with badges, league, country | Read-only |
-| `players` | Player identity, nationality, thumbnail | Read-only |
-| `player_clubs` | Player club history (joined/departed years) | Read-only |
-| `game_rooms` | Multiplayer game state | Read + Write |
-| `pool_refresh` | Tracks daily pool refresh | Read-only |
-| `daily_schedule` | Daily player selection (one per day) | Read + Insert |
+| `countries` | Country names | Read: anyone, Write: admin |
+| `clubs` | Club data with badges, league, country | Read: anyone, Write: admin |
+| `players` | Player identity, nationality, thumbnail | Read: anyone, Write: admin |
+| `player_clubs` | Player club history (joined/departed, loan/youth flags) | Read: anyone, Write: admin |
+| `game_rooms` | Multiplayer game state | Read + Write: anyone |
+| `pool_refresh` | Tracks daily pool refresh | Read: anyone, Write: admin |
+| `daily_schedule` | Daily player selection (one per day) | Read + Insert: anyone, Update + Delete: admin |
+| `admin_users` | Allowed admin emails | Read: admin only |
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ See a player's club history and guess who it is in **5 attempts**.
 - **Random** — Practice with random players from top European clubs
 - **Hard Mode** — Only club badges shown (no names or years)
 - **Hints** — Wrong guesses progressively reveal nationality, age, position, and photo
+- **Loan indicators** — Loan spells shown with dashed borders
 
 ## Tech Stack
 
 - React 19 + TypeScript
 - Vite 8
 - Tailwind CSS 4
-- [Supabase](https://supabase.com/) for player data and multiplayer game rooms
-- Player data sourced from [TransferMarkt](https://github.com/dcaribou/transfermarkt-datasets)
+- [Supabase](https://supabase.com/) for player data, multiplayer game rooms, and admin auth
+- Player data sourced from [TransferMarkt](https://github.com/dcaribou/transfermarkt-datasets) (~47,000 players)
 
 ## Development
 
@@ -48,10 +49,24 @@ VITE_SUPABASE_ANON_KEY=your-anon-key-here
 Import player data from TransferMarkt datasets:
 
 ```bash
-npx tsx scripts/import-transfermarkt.ts
+# Import players from top 7 European leagues
+SUPABASE_SERVICE_ROLE_KEY=your-key npx tsx scripts/import-transfermarkt.ts
+
+# Import all players from the dataset (~47k players)
+SUPABASE_SERVICE_ROLE_KEY=your-key npx tsx scripts/import-transfermarkt.ts --all
 ```
 
-This downloads player and transfer CSVs from TransferMarkt and populates the Supabase database with ~17,500 players from top European leagues. Requires the Supabase **service role key** (not the anon key).
+Requires the Supabase **service role key** (RLS restricts writes to admin users).
+
+### Admin interface
+
+The admin panel at `/#/admin` is protected by Supabase Auth (email/password). Admin users are managed via the `admin_users` database table.
+
+Features:
+- Curate the daily puzzle schedule (approve, skip, search any player)
+- Edit player club history (reorder, hide, mark as loan/youth team)
+- Upload club crests
+- Wiki lookup links for quick player reference
 
 ### Running tests
 

--- a/scripts/import-transfermarkt.ts
+++ b/scripts/import-transfermarkt.ts
@@ -2,10 +2,11 @@
  * Import player and transfer data from TransferMarkt datasets into Supabase.
  *
  * Usage:
- *   npx tsx scripts/import-transfermarkt.ts
+ *   npx tsx scripts/import-transfermarkt.ts          # Import target competitions only
+ *   npx tsx scripts/import-transfermarkt.ts --all    # Import all players from dataset
  *
  * Requires:
- *   VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY (or VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY)
+ *   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (or VITE_SUPABASE_ANON_KEY)
  *
  * Data source: https://github.com/dcaribou/transfermarkt-datasets
  */
@@ -32,6 +33,7 @@ const BASE_URL = "https://pub-e682421888d945d684bcae8890b0ec20.r2.dev/data";
 
 // Top 5 leagues + Portuguese + Dutch first divisions
 const TARGET_COMPETITIONS = new Set(["GB1", "ES1", "IT1", "L1", "FR1", "PO1", "NL1"]);
+const IMPORT_ALL = process.argv.includes("--all");
 
 interface CsvPlayer {
   player_id: string;
@@ -116,9 +118,11 @@ function extractYear(dateStr: string): string {
   return match ? match[1] : "";
 }
 
-async function upsertBatch(table: string, rows: Record<string, unknown>[], onConflict?: string) {
+async function upsertBatch(table: string, rows: Record<string, unknown>[], onConflict?: string, ignoreDuplicates?: boolean) {
   if (rows.length === 0) return;
-  const opts = onConflict ? { onConflict } : undefined;
+  const opts: Record<string, unknown> = {};
+  if (onConflict) opts.onConflict = onConflict;
+  if (ignoreDuplicates) opts.ignoreDuplicates = true;
   const { error } = await supabase.from(table).upsert(rows, opts);
   if (error) console.warn(`  Upsert error on ${table}: ${error.message}`);
 }
@@ -126,12 +130,12 @@ async function upsertBatch(table: string, rows: Record<string, unknown>[], onCon
 async function main() {
   console.log("=== TransferMarkt Data Import ===\n");
 
-  // Step 1: Load clubs from target competitions
-  console.log("Step 1: Loading clubs...");
+  // Step 1: Load clubs
+  console.log(`Step 1: Loading clubs${IMPORT_ALL ? " (all)" : " (target competitions)"}...`);
   const clubMap = new Map<string, { id: string; name: string; competition: string }>();
   const clubRows: Record<string, unknown>[] = [];
 
-  for await (const club of readCsvGz<CsvClub>("clubs", (c) => TARGET_COMPETITIONS.has(c.domestic_competition_id))) {
+  for await (const club of readCsvGz<CsvClub>("clubs", IMPORT_ALL ? undefined : (c) => TARGET_COMPETITIONS.has(c.domestic_competition_id))) {
     clubMap.set(club.club_id, { id: club.club_id, name: club.name, competition: club.domestic_competition_id });
     clubRows.push({
       id: `tm_${club.club_id}`,
@@ -141,22 +145,22 @@ async function main() {
       badge: `https://tmssl.akamaized.net/images/wappen/normquad/${club.club_id}.png`,
     });
   }
-  console.log(`  Found ${clubMap.size} clubs in target competitions`);
+  console.log(`  Found ${clubMap.size} clubs`);
 
-  // Batch upsert clubs
+  // Batch upsert clubs (ignoreDuplicates preserves existing club data including manually uploaded crests)
   for (let i = 0; i < clubRows.length; i += 500) {
-    await upsertBatch("clubs", clubRows.slice(i, i + 500));
+    await upsertBatch("clubs", clubRows.slice(i, i + 500), undefined, true);
   }
   console.log(`  Upserted ${clubRows.length} clubs`);
 
-  // Step 2: Load players from target competitions
-  console.log("\nStep 2: Loading players...");
+  // Step 2: Load players
+  console.log(`\nStep 2: Loading players${IMPORT_ALL ? " (all)" : " (target competitions)"}...`);
   const targetPlayerIds = new Set<string>();
   const playerRows: Record<string, unknown>[] = [];
   const countrySet = new Set<string>();
 
   for await (const player of readCsvGz<CsvPlayer>("players", (p) =>
-    TARGET_COMPETITIONS.has(p.current_club_domestic_competition_id) &&
+    (IMPORT_ALL || TARGET_COMPETITIONS.has(p.current_club_domestic_competition_id)) &&
     p.position !== "" &&
     p.position !== "Manager"
   )) {
@@ -200,7 +204,7 @@ async function main() {
   const playerClubs = new Map<string, Map<string, { clubId: string; clubName: string; joined: string; departed: string }>>();
 
   let transferCount = 0;
-  for await (const transfer of readCsvGz<CsvTransfer>("transfers", (t) => targetPlayerIds.has(t.player_id))) {
+  for await (const transfer of readCsvGz<CsvTransfer>("transfers", IMPORT_ALL ? undefined : (t) => targetPlayerIds.has(t.player_id))) {
     transferCount++;
     const pid = transfer.player_id;
     if (!playerClubs.has(pid)) playerClubs.set(pid, new Map());
@@ -267,7 +271,7 @@ async function main() {
     }
   }
   for (let i = 0; i < extraClubs.length; i += 500) {
-    await upsertBatch("clubs", extraClubs.slice(i, i + 500));
+    await upsertBatch("clubs", extraClubs.slice(i, i + 500), undefined, true);
   }
   console.log(`  Upserted ${extraClubs.length} extra clubs from transfers`);
 

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -1,7 +1,28 @@
 import { supabase } from "./supabaseClient";
+import type { Player } from "../types";
 import type { AdminClubRow } from "../pages/Admin/types";
 
-// --- Player thumbnail lookup ---
+// --- Player lookup ---
+
+export async function getPlayersByIds(
+  playerIds: string[],
+): Promise<Map<string, Player>> {
+  if (!supabase || playerIds.length === 0) return new Map();
+  const { data } = await supabase
+    .from("players")
+    .select("id, name, thumbnail, nationality_id, countries(name)")
+    .in("id", playerIds);
+  if (!data) return new Map();
+  return new Map((data as unknown as Array<{
+    id: string; name: string; thumbnail: string; nationality_id: string;
+    countries: { name: string } | null;
+  }>).map((r) => [r.id, {
+    id: r.id,
+    name: r.name,
+    thumbnail: r.thumbnail || "",
+    nationality: r.countries?.name ?? r.nationality_id ?? "",
+  }]));
+}
 
 export async function getPlayerThumbnails(
   playerIds: string[],

--- a/src/components/PlayerSearch/index.tsx
+++ b/src/components/PlayerSearch/index.tsx
@@ -55,7 +55,7 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeh
           const spaceBelow = window.innerHeight - rect.bottom;
           setDropUp(spaceBelow < 320);
         }
-        setIsOpen(filtered.length > 0);
+        setIsOpen(true);
       } catch {
         setResults([]);
         setIsOpen(false);
@@ -111,6 +111,11 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeh
       />
       {loading && (
         <div className="absolute right-3 top-3.5 text-gray-400 text-sm">...</div>
+      )}
+      {isOpen && !loading && results.length === 0 && (
+        <div className={`absolute z-10 w-full bg-gray-800 border border-gray-600 rounded-lg p-4 text-gray-400 text-sm ${dropUp ? "bottom-full mb-1" : "mt-1"}`}>
+          No players found
+        </div>
       )}
       {isOpen && results.length > 0 && (
         <ul

--- a/src/pages/Admin/ScheduleManager.tsx
+++ b/src/pages/Admin/ScheduleManager.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { SEED_PLAYERS } from "../../data/seedPlayers";
 import { getAllScheduledDays } from "../../api/dailySchedule";
-import { upsertSchedule, deleteSchedule, getScheduleRange, getPlayerThumbnails } from "../../api/adminApi";
-import { SCHEDULE_DAYS_AHEAD } from "./constants";
+import { upsertSchedule, deleteSchedule, getScheduleRange, getPlayerThumbnails, getPlayersByIds } from "../../api/adminApi";
+import { SCHEDULE_DAYS_AHEAD, SCHEDULE_DAYS_BACK } from "./constants";
 import type { Player } from "../../types";
+import PlayerSearch from "../../components/PlayerSearch";
 import PlayerClubList from "./PlayerClubList";
 
 function formatDate(dateStr: string): string {
@@ -15,10 +16,10 @@ function getTodayString(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function getDateRange(days: number): string[] {
+function getDateRange(daysBack: number, daysAhead: number): string[] {
   const today = new Date();
   const dates: string[] = [];
-  for (let i = 0; i < days; i++) {
+  for (let i = -daysBack; i < daysAhead; i++) {
     const d = new Date(today);
     d.setDate(today.getDate() + i);
     dates.push(d.toISOString().slice(0, 10));
@@ -36,6 +37,7 @@ export default function ScheduleManager() {
   const [days, setDays] = useState<DayState[]>([]);
   const [usedPlayerIds, setUsedPlayerIds] = useState<Set<string>>(new Set());
   const [expandedDate, setExpandedDate] = useState<string | null>(null);
+  const [showPast, setShowPast] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const today = useMemo(() => getTodayString(), []);
@@ -51,7 +53,7 @@ export default function ScheduleManager() {
 
   const loadSchedule = useCallback(async () => {
     setLoading(true);
-    const dates = getDateRange(SCHEDULE_DAYS_AHEAD);
+    const dates = getDateRange(SCHEDULE_DAYS_BACK, SCHEDULE_DAYS_AHEAD);
     const [allUsed, rangeData] = await Promise.all([
       getAllScheduledDays(),
       getScheduleRange(dates[0], dates[dates.length - 1]),
@@ -70,10 +72,15 @@ export default function ScheduleManager() {
     const withFreshThumbs = (p: Player): Player =>
       thumbnails.has(p.id) ? { ...p, thumbnail: thumbnails.get(p.id)! } : p;
 
+    // Fetch any scheduled players not in SEED_PLAYERS from the database
+    const scheduledIds = [...scheduleMap.values()];
+    const unknownIds = scheduledIds.filter((id) => !SEED_PLAYERS.some((p) => p.id === id));
+    const dbPlayers = unknownIds.length > 0 ? await getPlayersByIds(unknownIds) : new Map<string, Player>();
+
     const dayStates: DayState[] = dates.map((date) => {
       const assignedId = scheduleMap.get(date);
       const assignedPlayer = assignedId
-        ? (SEED_PLAYERS.find((p) => p.id === assignedId) ?? null)
+        ? (SEED_PLAYERS.find((p) => p.id === assignedId) ?? dbPlayers.get(assignedId) ?? null)
         : null;
 
       let suggestion: Player | null = null;
@@ -201,123 +208,165 @@ export default function ScheduleManager() {
       <h2 className="text-lg font-semibold mb-4">
         Daily Schedule
         <span className="text-gray-400 text-sm font-normal ml-2">
-          {SEED_PLAYERS.length - usedPlayerIds.size} players remaining
+          {SEED_PLAYERS.length - usedPlayerIds.size} seed players remaining
         </span>
       </h2>
 
-      {days.map((day) => {
-        const isPast = day.date < today;
-        const isToday = day.date === today;
-        const player = day.assignedPlayer ?? day.suggestion;
-        const isSuggestion = !day.assignedPlayer && !!day.suggestion;
-        const isExpanded = expandedDate === day.date;
+      <div className="mb-4">
+        <PlayerSearch
+          onSelect={(player) => handleApprove("", player)}
+          usedPlayerIds={usedPlayerIds}
+          placeholder="Search and add a player to schedule..."
+        />
+      </div>
 
-        return (
-          <div
-            key={day.date}
-            className={`rounded-lg border ${
-              isToday
-                ? "border-green-600 bg-gray-800"
-                : isPast
-                  ? "border-gray-700 bg-gray-800/50 opacity-60"
-                  : "border-gray-700 bg-gray-800"
-            }`}
-          >
-            {/* Day row */}
-            <div className="flex items-center gap-3 px-4 py-3">
-              {/* Date */}
-              <div className="w-32 shrink-0">
-                <div className="text-sm font-medium text-white">
-                  {formatDate(day.date)}
-                  {isToday && <span className="text-green-400 ml-1">(today)</span>}
+      {(() => {
+        const pastDays = days.filter((d) => d.date < today);
+        const currentAndFuture = days.filter((d) => d.date >= today);
+
+        function renderDay(day: DayState) {
+          const isPast = day.date < today;
+          const isToday = day.date === today;
+          const player = day.assignedPlayer ?? day.suggestion;
+          const isSuggestion = !day.assignedPlayer && !!day.suggestion;
+          const isExpanded = expandedDate === day.date;
+
+          return (
+            <div
+              key={day.date}
+              className={`rounded-lg border ${
+                isToday
+                  ? "border-green-600 bg-gray-800"
+                  : isPast
+                    ? "border-gray-700 bg-gray-800/50 opacity-60"
+                    : "border-gray-700 bg-gray-800"
+              }`}
+            >
+              {/* Day row */}
+              <div className="flex items-center gap-3 px-4 py-3">
+                {/* Date */}
+                <div className="w-32 shrink-0">
+                  <div className="text-sm font-medium text-white">
+                    {formatDate(day.date)}
+                    {isToday && <span className="text-green-400 ml-1">(today)</span>}
+                  </div>
+                  <div className="text-xs text-gray-500">{day.date}</div>
                 </div>
-                <div className="text-xs text-gray-500">{day.date}</div>
+
+                {/* Player info */}
+                {player ? (
+                  <button
+                    onClick={() => toggleExpand(day.date)}
+                    className="flex items-center gap-3 flex-1 text-left hover:bg-gray-700/50 rounded-lg px-2 py-1 -mx-2 -my-1 transition-colors"
+                  >
+                    {player.thumbnail && (
+                      <img
+                        src={player.thumbnail}
+                        alt=""
+                        referrerPolicy="no-referrer"
+                        className="w-8 h-8 rounded-full object-cover bg-gray-700"
+                      />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <span className={`font-medium ${isSuggestion ? "text-yellow-300" : "text-white"}`}>
+                        {player.name}
+                      </span>
+                      <a
+                        href={`https://duckduckgo.com/?q=${encodeURIComponent(player.name + " wiki")}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-gray-500 hover:text-blue-400 ml-1.5 inline-block transition-colors"
+                        title="Look up on Wikipedia"
+                      >
+                        <svg className="w-3.5 h-3.5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                        </svg>
+                      </a>
+                      {isSuggestion && (
+                        <span className="text-yellow-500/70 text-xs ml-2">suggestion</span>
+                      )}
+                      <div className="text-xs text-gray-400">{player.nationality}</div>
+                    </div>
+                    <svg
+                      className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                      fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                ) : (
+                  <span className="flex-1 text-gray-500 text-sm italic">No players available</span>
+                )}
+
+                {/* Actions */}
+                <div className="flex gap-2 shrink-0">
+                  {isSuggestion && !isPast && (
+                    <>
+                      <button
+                        onClick={() => handleApprove(day.date, day.suggestion!)}
+                        className="px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={() => handleReject(day.date)}
+                        className="px-3 py-1.5 bg-gray-600 hover:bg-gray-500 text-white text-sm font-medium rounded-lg transition-colors"
+                      >
+                        Skip
+                      </button>
+                    </>
+                  )}
+                  {day.assignedPlayer && !isPast && !isToday && (
+                    <button
+                      onClick={() => handleClear(day.date)}
+                      className="px-3 py-1.5 bg-red-600/20 hover:bg-red-600/40 text-red-400 text-sm font-medium rounded-lg transition-colors"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
               </div>
 
-              {/* Player info */}
-              {player ? (
+              {/* Expanded: club history */}
+              {isExpanded && player && (
+                <div className="border-t border-gray-700 px-4 py-3">
+                  <PlayerClubList playerId={player.id} />
+                </div>
+              )}
+            </div>
+          );
+        }
+
+        return (
+          <>
+            {pastDays.length > 0 && (
+              <div>
                 <button
-                  onClick={() => toggleExpand(day.date)}
-                  className="flex items-center gap-3 flex-1 text-left hover:bg-gray-700/50 rounded-lg px-2 py-1 -mx-2 -my-1 transition-colors"
+                  onClick={() => setShowPast((p) => !p)}
+                  className="flex items-center gap-2 text-gray-400 hover:text-white text-sm mb-2 transition-colors"
                 >
-                  {player.thumbnail && (
-                    <img
-                      src={player.thumbnail}
-                      alt=""
-                      referrerPolicy="no-referrer"
-                      className="w-8 h-8 rounded-full object-cover bg-gray-700"
-                    />
-                  )}
-                  <div className="flex-1 min-w-0">
-                    <span className={`font-medium ${isSuggestion ? "text-yellow-300" : "text-white"}`}>
-                      {player.name}
-                    </span>
-                    <a
-                      href={`https://duckduckgo.com/?q=${encodeURIComponent(player.name + " wiki")}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      className="text-gray-500 hover:text-blue-400 ml-1.5 inline-block transition-colors"
-                      title="Look up on Wikipedia"
-                    >
-                      <svg className="w-3.5 h-3.5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                      </svg>
-                    </a>
-                    {isSuggestion && (
-                      <span className="text-yellow-500/70 text-xs ml-2">suggestion</span>
-                    )}
-                    <div className="text-xs text-gray-400">{player.nationality}</div>
-                  </div>
                   <svg
-                    className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                    className={`w-4 h-4 transition-transform ${showPast ? "rotate-180" : ""}`}
                     fill="none" viewBox="0 0 24 24" stroke="currentColor"
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
+                  Previous dailies ({pastDays.length})
                 </button>
-              ) : (
-                <span className="flex-1 text-gray-500 text-sm italic">No players available</span>
-              )}
-
-              {/* Actions */}
-              <div className="flex gap-2 shrink-0">
-                {isSuggestion && !isPast && (
-                  <>
-                    <button
-                      onClick={() => handleApprove(day.date, day.suggestion!)}
-                      className="px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Approve
-                    </button>
-                    <button
-                      onClick={() => handleReject(day.date)}
-                      className="px-3 py-1.5 bg-gray-600 hover:bg-gray-500 text-white text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Skip
-                    </button>
-                  </>
+                {showPast && (
+                  <div className="space-y-2 mb-4">
+                    {pastDays.map(renderDay)}
+                  </div>
                 )}
-                {day.assignedPlayer && !isPast && !isToday && (
-                  <button
-                    onClick={() => handleClear(day.date)}
-                    className="px-3 py-1.5 bg-red-600/20 hover:bg-red-600/40 text-red-400 text-sm font-medium rounded-lg transition-colors"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-            </div>
-
-            {/* Expanded: club history */}
-            {isExpanded && player && (
-              <div className="border-t border-gray-700 px-4 py-3">
-                <PlayerClubList playerId={player.id} />
               </div>
             )}
-          </div>
+            <div className="space-y-2">
+              {currentAndFuture.map(renderDay)}
+            </div>
+          </>
         );
-      })}
+      })()}
     </div>
   );
 }

--- a/src/pages/Admin/constants.ts
+++ b/src/pages/Admin/constants.ts
@@ -1,1 +1,2 @@
 export const SCHEDULE_DAYS_AHEAD = 14;
+export const SCHEDULE_DAYS_BACK = 21;


### PR DESCRIPTION
## Summary
- Add player search bar to schedule manager — search any player in the database and add to the next open slot
- Support scheduling players outside the seed list (fetches from DB on load)
- Show past 21 days in a collapsible "Previous dailies" section for editing club history
- Show "No players found" message in search when query returns empty
- Add `--all` flag to import script for full TransferMarkt dataset backfill (~47k players)
- Use `ignoreDuplicates` for clubs upsert to preserve manually uploaded crests

## Test plan
- [ ] Search for a non-seed player, add to schedule — appears correctly
- [ ] Refresh page — non-seed player still shows with name/thumbnail
- [ ] "Previous dailies" section collapsed by default, expands to show past days
- [ ] Past days expandable for club history editing
- [ ] Search with no results shows "No players found"
- [ ] Existing seed player approve/skip/clear still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)