### PR TITLE
fix: use pool_refresh timestamp for data updated display

### DIFF
--- a/src/api/playerCache.ts
+++ b/src/api/playerCache.ts
@@ -236,3 +236,14 @@ export async function getPlayerWithTeamsCached(player: Player): Promise<PlayerWi
   if (cached) return cached;
   throw new Error(`Player "${player.name}" not found in database`);
 }
+
+export async function getLastRefresh(): Promise<string | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from("pool_refresh")
+    .select("last_refresh")
+    .eq("id", "singleton")
+    .single();
+  if (error || !data) return null;
+  return data.last_refresh;
+}

--- a/src/pages/GuessThePlayer/index.tsx
+++ b/src/pages/GuessThePlayer/index.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useGuessGame } from "./useGuessGame";
 import { HARD_MODE_KEY } from "./constants";
 import { mergeConsecutiveClubs, getTodayString } from "./helpers";
 import PlayerCard from "../../components/PlayerCard";
+import { getLastRefresh } from "../../api/playerCache";
 
 export default function GuessThePlayer() {
   const navigate = useNavigate();
@@ -40,6 +41,11 @@ export default function GuessThePlayer() {
   });
   const [hardMode, setHardMode] = useState(!hardModeDisabled);
   const [copied, setCopied] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<string | null>(null);
+
+  useEffect(() => {
+    getLastRefresh().then(setLastRefresh);
+  }, []);
 
   function toggleHardMode() {
     if (hardMode) {
@@ -288,9 +294,9 @@ export default function GuessThePlayer() {
 
       {targetPlayer && (
         <footer className="py-4 text-center space-y-1">
-          {targetPlayer.cachedAt && (
+          {lastRefresh && (
             <p className="text-gray-600 text-xs">
-              Data updated: {new Date(targetPlayer.cachedAt).toLocaleDateString("en-GB")}
+              Data updated: {new Date(lastRefresh).toLocaleDateString("en-GB")}
             </p>
           )}
           {(status === "won" || status === "lost") && (


### PR DESCRIPTION
## Summary
- The "Data updated" footer in Guess the Player was showing the per-player `cached_at` timestamp, which reflects when the player row was originally inserted — not when the data was last refreshed
- Now queries the `pool_refresh` table's `last_refresh` date instead, which accurately reflects when the data pool was updated

## Test plan
- [ ] Verify "Data updated" shows the correct date from `pool_refresh.last_refresh`
- [ ] Verify the timestamp still appears in the footer after a game loads
- [ ] E2E test `shows data updated timestamp` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)