### PR TITLE
feat: legacy player card styling with admin override

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -70,6 +70,31 @@ export async function getScheduleRange(
   return data ?? [];
 }
 
+// --- Player field operations ---
+
+export async function getPlayerLegacyStatus(playerId: string): Promise<boolean | null> {
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from("players")
+    .select("is_legacy")
+    .eq("id", playerId)
+    .single();
+  return data?.is_legacy ?? null;
+}
+
+export async function updatePlayerLegacy(
+  playerId: string,
+  isLegacy: boolean | null,
+): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("players")
+    .update({ is_legacy: isLegacy })
+    .eq("id", playerId);
+  if (error) console.error("updatePlayerLegacy failed:", error);
+  return !error;
+}
+
 // --- Club history operations ---
 
 export async function getPlayerClubsAdmin(playerId: string): Promise<AdminClubRow[]> {

--- a/src/api/playerCache.ts
+++ b/src/api/playerCache.ts
@@ -79,11 +79,12 @@ interface PlayerRow {
   position: string;
   date_born: string;
   cached_at: string;
+  is_legacy: boolean | null;
   player_clubs: PlayerClubRow[];
   countries: { name: string } | null;
 }
 
-const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, countries(name), player_clubs(club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(id, name, badge))";
+const PLAYER_SELECT = "id, name, thumbnail, nationality_id, position, date_born, cached_at, is_legacy, countries(name), player_clubs(club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(id, name, badge))";
 
 let countryNamesCache: Set<string> | null = null;
 
@@ -189,6 +190,7 @@ async function buildPlayerWithTeams(row: PlayerRow): Promise<PlayerWithTeams> {
     cachedAt: row.cached_at,
     position: row.position || undefined,
     dateBorn: row.date_born || undefined,
+    isLegacy: row.is_legacy,
   };
 }
 

--- a/src/components/PlayerCard/index.tsx
+++ b/src/components/PlayerCard/index.tsx
@@ -43,20 +43,45 @@ function RevealedField({ label, value }: { label: string; value: string }) {
 export default function PlayerCard({ player, clubs, hints, revealed, hardMode, result, onGuess }: PlayerCardProps) {
   const age = player.dateBorn ? new Date().getFullYear() - parseInt(player.dateBorn, 10) : null;
 
-  const borderColor = result === "won" ? "border-green-600" : result === "lost" ? "border-red-600" : "border-gray-600";
+  // A player is considered "legacy" (potentially retired) if all their clubs have a departure year.
+  // The is_legacy DB field overrides auto-detection when set.
+  const autoLegacy = clubs.length > 0 && clubs.every((c) => c.yearDeparted);
+  const isLegacy = player.isLegacy != null ? player.isLegacy : autoLegacy;
+
+  const borderColor = result === "won" ? "border-green-600" : result === "lost" ? "border-red-600" : isLegacy ? "border-amber-700/60" : "border-gray-600";
 
   return (
-    <div className={`bg-gray-800 border-2 ${borderColor} rounded-2xl overflow-visible max-w-md w-full transition-colors duration-500`}>
+    <div className={`${isLegacy ? "bg-gray-800/90" : "bg-gray-800"} border-2 ${borderColor} rounded-2xl overflow-visible max-w-md w-full transition-colors duration-500 relative`}>
+      {/* Legacy badge */}
+      {isLegacy && (
+        <div className="absolute -top-3 right-4 flex items-center gap-1.5 bg-amber-900/80 border border-amber-700/60 rounded-full px-3 py-1 z-10">
+          <span className="text-amber-300 text-xs font-medium">Legacy Player</span>
+          <div className="relative group">
+            <button
+              type="button"
+              aria-label="This player is potentially retired"
+              className="text-amber-400/70 hover:text-amber-300 text-xs select-none focus:outline-none"
+            >
+              &#9432;
+            </button>
+            <div className="absolute bottom-full right-0 mb-2 w-48 px-3 py-2 bg-gray-700 text-gray-200 text-xs rounded-lg shadow-lg pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-center z-20">
+              This player is potentially retired — their club history has no current team.
+              <div className="absolute top-full right-4 border-4 border-transparent border-t-gray-700" />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Player identity header */}
       <div className="px-6 pt-5 pb-4 flex items-center gap-4 border-b border-gray-700">
         {(revealed || hints.photo) && player.thumbnail ? (
           <img
             src={player.thumbnail}
             alt={revealed ? player.name : ""}
-            className="w-20 h-20 rounded-full object-cover bg-gray-700 border-2 border-gray-600 shrink-0"
+            className={`w-20 h-20 rounded-full object-cover bg-gray-700 border-2 shrink-0 ${isLegacy ? "border-amber-700/50 sepia-[.3]" : "border-gray-600"}`}
           />
         ) : (
-          <div className="w-20 h-20 rounded-full bg-gray-700 border-2 border-gray-600 flex items-center justify-center text-3xl text-gray-500 select-none shrink-0">
+          <div className={`w-20 h-20 rounded-full bg-gray-700 border-2 flex items-center justify-center text-3xl text-gray-500 select-none shrink-0 ${isLegacy ? "border-amber-700/50" : "border-gray-600"}`}>
             ?
           </div>
         )}
@@ -92,7 +117,7 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
 
       {/* Club history */}
       <div className="px-6 pb-5 pt-2">
-        <p className="text-xs text-gray-500 uppercase tracking-wider mb-3">Club History</p>
+        <p className={`text-xs uppercase tracking-wider mb-3 ${isLegacy ? "text-amber-600/80" : "text-gray-500"}`}>Club History</p>
         {hardMode && !revealed ? (
           <div className="flex items-center justify-center gap-1 flex-wrap">
             {clubs.map((club, i) => (

--- a/src/components/PlayerCard/index.tsx
+++ b/src/components/PlayerCard/index.tsx
@@ -65,7 +65,7 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
               &#9432;
             </button>
             <div className="absolute bottom-full right-0 mb-2 w-48 px-3 py-2 bg-gray-700 text-gray-200 text-xs rounded-lg shadow-lg pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-center z-20">
-              This player is potentially retired — their club history has no current team.
+              This player is potentially retired — no current team in their career data.
               <div className="absolute top-full right-4 border-4 border-transparent border-t-gray-700" />
             </div>
           </div>

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import {
   getPlayerClubsAdmin,
+  getPlayerLegacyStatus,
   updatePlayerClubHidden,
   updatePlayerClubYouthTeam,
   updatePlayerClubLoan,
+  updatePlayerLegacy,
   updateClubSortOrders,
   updateClubName,
 } from "../../api/adminApi";
@@ -19,17 +21,29 @@ export default function PlayerClubList({ playerId }: Props) {
   const [loading, setLoading] = useState(true);
   const [editingNameId, setEditingNameId] = useState<number | null>(null);
   const [editNameValue, setEditNameValue] = useState("");
+  const [legacyOverride, setLegacyOverride] = useState<boolean | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    getPlayerClubsAdmin(playerId).then((data) => {
+    Promise.all([
+      getPlayerClubsAdmin(playerId),
+      getPlayerLegacyStatus(playerId),
+    ]).then(([data, legacy]) => {
       if (!cancelled) {
         setClubs(data);
+        setLegacyOverride(legacy);
         setLoading(false);
       }
     });
     return () => { cancelled = true; };
   }, [playerId]);
+
+  async function cycleLegacy() {
+    // Cycle: null (auto) → true (force legacy) → false (force not legacy) → null
+    const next = legacyOverride === null ? true : legacyOverride === true ? false : null;
+    const ok = await updatePlayerLegacy(playerId, next);
+    if (ok) setLegacyOverride(next);
+  }
 
   async function toggleHidden(club: AdminClubRow) {
     const newHidden = !club.is_hidden;
@@ -119,11 +133,28 @@ export default function PlayerClubList({ playerId }: Props) {
     return <p className="text-gray-500 text-sm py-2">No club history found.</p>;
   }
 
+  const autoLegacy = clubs.length > 0 && clubs.every((c) => c.year_departed);
+  const effectiveLegacy = legacyOverride != null ? legacyOverride : autoLegacy;
+
   return (
     <div className="space-y-1.5">
-      <p className="text-xs text-gray-500 mb-2">
-        Drag badge to upload crest. Click name to edit. Arrows to reorder.
-      </p>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-gray-500">
+          Drag badge to upload crest. Click name to edit. Arrows to reorder.
+        </p>
+        <button
+          onClick={cycleLegacy}
+          className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+            effectiveLegacy
+              ? "bg-amber-900/50 border-amber-700/60 text-amber-300"
+              : "bg-gray-700 border-gray-600 text-gray-400"
+          }`}
+          title={`Legacy status: ${legacyOverride === null ? "auto" : legacyOverride ? "forced on" : "forced off"} (click to cycle)`}
+        >
+          {legacyOverride === null ? "Legacy: Auto" : legacyOverride ? "Legacy: On" : "Legacy: Off"}
+          {legacyOverride === null && (effectiveLegacy ? " (yes)" : " (no)")}
+        </button>
+      </div>
       {clubs.map((club, index) => (
         <div
           key={club.id}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface PlayerWithTeams extends Player {
   cachedAt?: string;
   position?: string;
   dateBorn?: string;
+  isLegacy?: boolean | null;
 }
 
 export type RoomStatus = "waiting" | "playing" | "finished";

--- a/supabase/migrations/009_legacy_player.sql
+++ b/supabase/migrations/009_legacy_player.sql
@@ -1,0 +1,5 @@
+-- Add optional legacy override to players table
+-- NULL = auto-detect from club history (default)
+-- TRUE = force legacy display
+-- FALSE = force non-legacy display
+ALTER TABLE players ADD COLUMN IF NOT EXISTS is_legacy BOOLEAN DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Retired/legacy players get a vintage-styled card: amber border, "Legacy Player" pill with info tooltip, subtle sepia photo tint, amber "Club History" label
- Auto-detected from club history (all clubs have a departure year)
- Admin can override via 3-state toggle (Auto / On / Off) in the player club list panel
- Adds `is_legacy` nullable boolean column to `players` table

## Migration required
Run on both staging and production:
```sql
ALTER TABLE players ADD COLUMN IF NOT EXISTS is_legacy BOOLEAN DEFAULT NULL;
```

## Test plan
- [ ] Run migration on staging
- [ ] Verify legacy styling appears for retired players (e.g. `?id=tm_3220` Riise)
- [ ] Verify active players don't show legacy styling
- [ ] Test admin override toggle cycles: Auto → On → Off → Auto
- [ ] Verify tooltip shows on hover/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)