### PR TITLE
fix: optimistically show user result in leaderboard

### DIFF
--- a/src/components/DailyLeaderboard/index.tsx
+++ b/src/components/DailyLeaderboard/index.tsx
@@ -31,7 +31,14 @@ export default function DailyLeaderboard({ date, userAttempts }: Props) {
   if (loading) return null;
 
   const countMap = new Map(entries.map((e) => [e.attempts, e.count]));
-  const total = entries.reduce((sum, e) => sum + e.count, 0);
+
+  // Optimistically include the user's result if not yet in the data
+  const userCount = countMap.get(userAttempts) ?? 0;
+  if (userCount === 0) {
+    countMap.set(userAttempts, 1);
+  }
+
+  const total = [...countMap.values()].reduce((sum, c) => sum + c, 0);
   const maxCount = Math.max(...ALL_BUCKETS.map((b) => countMap.get(b) ?? 0), 1);
 
   if (total === 0) return null;


### PR DESCRIPTION
## Summary
- The leaderboard fetch was racing with the result submission, so the user's own bar wasn't highlighted on first render
- Now optimistically includes the user's result in the count if not yet present in the fetched data

## Test plan
- [x] Complete a daily game — leaderboard should immediately show your result highlighted
- [x] No need to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)