### PR TITLE
feat: reveal player initials as final hint

### DIFF
--- a/src/components/PlayerCard/index.tsx
+++ b/src/components/PlayerCard/index.tsx
@@ -89,7 +89,12 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
           {revealed ? (
             <p className="text-xl font-bold truncate">{player.name}</p>
           ) : onGuess ? (
-            <PlayerSearch onSelect={onGuess} placeholder="Player name" />
+            <PlayerSearch
+              onSelect={onGuess}
+              placeholder={hints.initials
+                ? player.name.split(" ").map((part) => part[0] + ".".repeat(part.length - 1)).join(" ")
+                : "Player name"}
+            />
           ) : (
             <>
               <div className="h-6 bg-gray-700 rounded w-40 mb-2" />

--- a/src/pages/GuessThePlayer/types.ts
+++ b/src/pages/GuessThePlayer/types.ts
@@ -7,6 +7,7 @@ export interface RevealedHints {
   age: boolean;
   position: boolean;
   photo: boolean;
+  initials: boolean;
 }
 
 export interface GuessGameState {

--- a/src/pages/GuessThePlayer/useGuessGame.ts
+++ b/src/pages/GuessThePlayer/useGuessGame.ts
@@ -11,7 +11,7 @@ import {
   loadStats, recordResult
 } from "./helpers";
 
-const NO_HINTS: RevealedHints = { nationality: false, age: false, position: false, photo: false };
+const NO_HINTS: RevealedHints = { nationality: false, age: false, position: false, photo: false, initials: false };
 
 function hintsForWrongCount(wrongCount: number): RevealedHints {
   return {
@@ -19,6 +19,7 @@ function hintsForWrongCount(wrongCount: number): RevealedHints {
     age: wrongCount >= 2,
     position: wrongCount >= 3,
     photo: wrongCount >= 4,
+    initials: wrongCount >= 4,
   };
 }
 


### PR DESCRIPTION
## Summary
- After 4 wrong guesses (last attempt), the search placeholder reveals the first letter of each name part with dots matching the remaining length
- e.g. "Luka Modrić" → `L... M.....`, "John Arne Riise" → `J... A... R....`
- Gives players a fighting chance on their final attempt if they know the player

## Test plan
- [x] Make 4 wrong guesses — placeholder should change from "Player name" to initials
- [x] Verify dot count matches actual name length
- [x] Verify initials don't show before 4th wrong guess
- [x] Verify initials don't appear in hard mode badge-only view (they don't — it's in the search input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)