### PR TITLE
feat: skip button, admin scheduled player labels, legacy fix

### DIFF
--- a/src/components/PlayerCard/index.tsx
+++ b/src/components/PlayerCard/index.tsx
@@ -40,12 +40,16 @@ function RevealedField({ label, value }: { label: string; value: string }) {
   );
 }
 
-export default function PlayerCard({ player, clubs, hints, revealed, hardMode, result, onGuess }: PlayerCardProps) {
+export default function PlayerCard({ player, clubs, hints, revealed, hardMode, result, onGuess, onSkip, attempts, maxAttempts }: PlayerCardProps) {
   const age = player.dateBorn ? new Date().getFullYear() - parseInt(player.dateBorn, 10) : null;
 
-  // A player is considered "legacy" (potentially retired) if all their clubs have a departure year.
+  // A player is considered "legacy" (potentially retired) if all their clubs have a departure year
+  // and none departed in the current or previous year (still potentially active).
   // The is_legacy DB field overrides auto-detection when set.
-  const autoLegacy = clubs.length > 0 && clubs.every((c) => c.yearDeparted);
+  const lastYear = String(new Date().getFullYear() - 1);
+  const autoLegacy = clubs.length > 0
+    && clubs.every((c) => c.yearDeparted)
+    && clubs.every((c) => c.yearDeparted < lastYear);
   const isLegacy = player.isLegacy != null ? player.isLegacy : autoLegacy;
 
   const borderColor = result === "won" ? "border-green-600" : result === "lost" ? "border-red-600" : isLegacy ? "border-amber-700/60" : "border-gray-600";
@@ -89,12 +93,25 @@ export default function PlayerCard({ player, clubs, hints, revealed, hardMode, r
           {revealed ? (
             <p className="text-xl font-bold truncate">{player.name}</p>
           ) : onGuess ? (
-            <PlayerSearch
-              onSelect={onGuess}
-              placeholder={hints.initials
-                ? player.name.split(" ").map((part) => part[0] + ".".repeat(part.length - 1)).join(" ")
-                : "Player name"}
-            />
+            <div className="flex items-center gap-2 w-full">
+              <div className="flex-1 min-w-0">
+                <PlayerSearch
+                  onSelect={onGuess}
+                  placeholder={hints.initials
+                    ? player.name.split(" ").map((part) => part[0] + ".".repeat(part.length - 1)).join(" ")
+                    : "Player name"}
+                />
+              </div>
+              {onSkip && (
+                <button
+                  onClick={onSkip}
+                  className="px-3 py-3 bg-gray-700 hover:bg-gray-600 text-gray-400 hover:text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+                  title={`Skip and reveal hint (${(attempts ?? 0) + 1}/${maxAttempts ?? 5})`}
+                >
+                  Skip
+                </button>
+              )}
+            </div>
           ) : (
             <>
               <div className="h-6 bg-gray-700 rounded w-40 mb-2" />

--- a/src/components/PlayerCard/types.ts
+++ b/src/components/PlayerCard/types.ts
@@ -19,4 +19,7 @@ export interface PlayerCardProps {
   hardMode: boolean;
   result?: "won" | "lost";
   onGuess?: (player: Player) => void;
+  onSkip?: () => void;
+  attempts?: number;
+  maxAttempts?: number;
 }

--- a/src/components/PlayerSearch/index.tsx
+++ b/src/components/PlayerSearch/index.tsx
@@ -3,7 +3,7 @@ import { searchPlayers } from "../../api/playerCache";
 import type { Player } from "../../types";
 import type { PlayerSearchProps } from "./types";
 
-export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeholder }: PlayerSearchProps) {
+export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, disabledPlayerIds, placeholder }: PlayerSearchProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Player[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -64,7 +64,12 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeh
     }, 300);
   }
 
+  function isPlayerDisabled(player: Player): boolean {
+    return disabledPlayerIds?.has(player.id) ?? false;
+  }
+
   function handleSelect(player: Player) {
+    if (isPlayerDisabled(player)) return;
     setQuery("");
     setResults([]);
     setIsOpen(false);
@@ -126,18 +131,24 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeh
             dropUp ? "bottom-full mb-1" : "mt-1"
           }`}
         >
-          {results.map((player, index) => (
+          {results.map((player, index) => {
+            const disabledReason = disabledPlayerIds?.get(player.id);
+            return (
             <li
               key={player.id}
               id={`player-option-${index}`}
               role="option"
               aria-selected={index === highlightIndex}
+              aria-disabled={!!disabledReason}
             >
               <button
                 onClick={() => handleSelect(player)}
                 onMouseEnter={() => setHighlightIndex(index)}
+                disabled={!!disabledReason}
                 className={`w-full px-4 py-3 flex items-center gap-3 text-left transition-colors ${
-                  index === highlightIndex ? "bg-gray-700" : "hover:bg-gray-700"
+                  disabledReason
+                    ? "opacity-50 cursor-not-allowed"
+                    : index === highlightIndex ? "bg-gray-700" : "hover:bg-gray-700"
                 }`}
               >
                 {player.thumbnail && (
@@ -147,13 +158,17 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, placeh
                     className="w-10 h-10 rounded-full object-cover bg-gray-700"
                   />
                 )}
-                <div>
+                <div className="flex-1 min-w-0">
                   <div className="text-white font-medium">{player.name}</div>
                   <div className="text-gray-400 text-sm">{player.nationality}</div>
                 </div>
+                {disabledReason && (
+                  <span className="text-gray-500 text-xs shrink-0">{disabledReason}</span>
+                )}
               </button>
             </li>
-          ))}
+          );
+          })}
         </ul>
       )}
     </div>

--- a/src/components/PlayerSearch/types.ts
+++ b/src/components/PlayerSearch/types.ts
@@ -4,5 +4,6 @@ export interface PlayerSearchProps {
   onSelect: (player: Player) => void;
   disabled?: boolean;
   usedPlayerIds?: Set<string>;
+  disabledPlayerIds?: Map<string, string>;  // id → reason label (shown but not selectable)
   placeholder?: string;
 }

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -133,7 +133,10 @@ export default function PlayerClubList({ playerId }: Props) {
     return <p className="text-gray-500 text-sm py-2">No club history found.</p>;
   }
 
-  const autoLegacy = clubs.length > 0 && clubs.every((c) => c.year_departed);
+  const lastYear = String(new Date().getFullYear() - 1);
+  const autoLegacy = clubs.length > 0
+    && clubs.every((c) => c.year_departed)
+    && clubs.every((c) => c.year_departed < lastYear);
   const effectiveLegacy = legacyOverride != null ? legacyOverride : autoLegacy;
 
   return (

--- a/src/pages/Admin/ScheduleManager.tsx
+++ b/src/pages/Admin/ScheduleManager.tsx
@@ -36,6 +36,7 @@ interface DayState {
 export default function ScheduleManager() {
   const [days, setDays] = useState<DayState[]>([]);
   const [usedPlayerIds, setUsedPlayerIds] = useState<Set<string>>(new Set());
+  const [scheduledPlayerLabels, setScheduledPlayerLabels] = useState<Map<string, string>>(new Map());
   const [expandedDate, setExpandedDate] = useState<string | null>(null);
   const [showPast, setShowPast] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -61,6 +62,13 @@ export default function ScheduleManager() {
 
     const allUsedIds = new Set(allUsed.map((r) => r.player_id));
     setUsedPlayerIds(allUsedIds);
+
+    const labels = new Map<string, string>();
+    for (const row of allUsed) {
+      const isPast = row.date < today;
+      labels.set(row.player_id, isPast ? `Played ${row.date}` : `Scheduled ${row.date}`);
+    }
+    setScheduledPlayerLabels(labels);
 
     const scheduleMap = new Map(rangeData.map((r) => [r.date, r.player_id]));
 
@@ -215,7 +223,7 @@ export default function ScheduleManager() {
       <div className="mb-4">
         <PlayerSearch
           onSelect={(player) => handleApprove("", player)}
-          usedPlayerIds={usedPlayerIds}
+          disabledPlayerIds={scheduledPlayerLabels}
           placeholder="Search and add a player to schedule..."
         />
       </div>

--- a/src/pages/GuessThePlayer/index.tsx
+++ b/src/pages/GuessThePlayer/index.tsx
@@ -27,6 +27,7 @@ export default function GuessThePlayer() {
     startRandom,
     loadArchiveDay,
     submitGuess,
+    skipGuess,
     getShareText,
   } = useGuessGame();
 
@@ -192,6 +193,9 @@ export default function GuessThePlayer() {
               revealed={false}
               hardMode={hardMode}
               onGuess={submitGuess}
+              onSkip={skipGuess}
+              attempts={attempts}
+              maxAttempts={maxAttempts}
             />
 
             {wrongGuesses.length > 0 && (

--- a/src/pages/GuessThePlayer/useGuessGame.ts
+++ b/src/pages/GuessThePlayer/useGuessGame.ts
@@ -214,6 +214,36 @@ export function useGuessGame() {
     [state.targetPlayer, state.status, state.attempts, state.isDaily, state.isArchive, state.dayNumber]
   );
 
+  const skipGuess = useCallback(() => {
+    if (!state.targetPlayer || state.status !== "playing") return;
+    const newAttempts = state.attempts + 1;
+    const newHints = hintsForWrongCount(newAttempts);
+    if (newAttempts >= MAX_ATTEMPTS) {
+      if (state.isDaily) {
+        saveDailyResult("lost", newAttempts);
+        setStats(recordResult(false));
+        submitDailyResult(today, false, newAttempts);
+      } else if (state.isArchive && state.dayNumber) {
+        const archiveDate = getDateForDay(state.dayNumber);
+        saveDailyResultForDate(archiveDate, "lost", newAttempts);
+        submitDailyResult(archiveDate, false, newAttempts);
+      }
+      setState((s) => ({
+        ...s,
+        attempts: newAttempts,
+        status: "lost",
+        dailyCompleted: s.isDaily,
+        hints: newHints,
+      }));
+    } else {
+      setState((s) => ({
+        ...s,
+        attempts: newAttempts,
+        hints: newHints,
+      }));
+    }
+  }, [state.targetPlayer, state.status, state.attempts, state.isDaily, state.isArchive, state.dayNumber, today]);
+
   function getShareText(hardMode?: boolean): string {
     const dayNum = state.dayNumber ?? getDayNumber(today);
     const won = state.status === "won";
@@ -281,6 +311,7 @@ export function useGuessGame() {
     startDaily,
     startRandom,
     submitGuess,
+    skipGuess,
     getShareText,
   };
 }


### PR DESCRIPTION
## Summary
- **Skip button**: Next to the search input — lets players burn an attempt to reveal the next hint without guessing
- **Admin search**: Scheduled players now shown as disabled with a date label ("Played 2026-04-10" / "Scheduled 2026-04-16") instead of being hidden from results
- **Legacy fix**: Players with clubs departing in the current or previous year are no longer auto-marked as legacy (e.g. a player whose last club is 2025–2026 is still active)

## Test plan
- [x] Skip button appears next to search, burns an attempt and reveals hint
- [x] Skipping 5 times results in a loss
- [x] Admin search: searching a scheduled player shows them greyed out with date label
- [x] Active players (club departing 2025/2026) are not shown as legacy
- [x] Players departing before 2025 are still shown as legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)