### PR TITLE
fix: break streak when daily puzzle is skipped

### DIFF
--- a/src/__tests__/guessStats.test.ts
+++ b/src/__tests__/guessStats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { loadStats, recordResult } from "../pages/GuessThePlayer/helpers";
-import { STATS_KEY } from "../pages/GuessThePlayer/constants";
+import { DAILY_GUESS_KEY, DAILY_RESULT_PREFIX, STATS_KEY } from "../pages/GuessThePlayer/constants";
 
 function installLocalStorageShim() {
   const store = new Map<string, string>();
@@ -101,15 +101,91 @@ describe("loadStats — display-time stale streak", () => {
     expect(stats.longestStreak).toBe(0);
   });
 
-  it("preserves legacy stats without lastPlayedDate", () => {
-    // Simulate a pre-fix stats blob with no lastPlayedDate
+  it("keeps legacy stats intact when no per-date results exist to infer from", () => {
     localStorage.setItem(
       STATS_KEY,
       JSON.stringify({ played: 5, won: 4, lost: 1, streak: 4, longestStreak: 4 })
     );
     const stats = loadStats("2026-04-20");
-    // No lastPlayedDate means we can't detect a gap — show as-is
     expect(stats.streak).toBe(4);
     expect(stats.longestStreak).toBe(4);
+  });
+});
+
+describe("loadStats — legacy backfill of lastPlayedDate", () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it("infers lastPlayedDate from per-date result keys and breaks stale streak", () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({ played: 5, won: 5, lost: 0, streak: 5, longestStreak: 5 })
+    );
+    localStorage.setItem(
+      DAILY_RESULT_PREFIX + "2026-04-15",
+      JSON.stringify({ date: "2026-04-15", status: "won", attempts: 3 })
+    );
+    localStorage.setItem(
+      DAILY_RESULT_PREFIX + "2026-04-17",
+      JSON.stringify({ date: "2026-04-17", status: "won", attempts: 2 })
+    );
+    const stats = loadStats("2026-04-20");
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(5);
+  });
+
+  it("keeps streak intact when inferred lastPlayedDate is within 1 day", () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({ played: 5, won: 5, lost: 0, streak: 5, longestStreak: 5 })
+    );
+    localStorage.setItem(
+      DAILY_RESULT_PREFIX + "2026-04-19",
+      JSON.stringify({ date: "2026-04-19", status: "won", attempts: 3 })
+    );
+    const stats = loadStats("2026-04-20");
+    expect(stats.streak).toBe(5);
+  });
+
+  it("falls back to legacy single daily key when no per-date results exist", () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({ played: 3, won: 3, lost: 0, streak: 3, longestStreak: 3 })
+    );
+    localStorage.setItem(
+      DAILY_GUESS_KEY,
+      JSON.stringify({ date: "2026-04-10", status: "won", attempts: 2 })
+    );
+    const stats = loadStats("2026-04-20");
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(3);
+  });
+
+  it("persists inferred lastPlayedDate on next recordResult", () => {
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({ played: 5, won: 5, lost: 0, streak: 5, longestStreak: 5 })
+    );
+    localStorage.setItem(
+      DAILY_RESULT_PREFIX + "2026-04-15",
+      JSON.stringify({ date: "2026-04-15", status: "won", attempts: 3 })
+    );
+    const stats = recordResult(true, "2026-04-20");
+    // streak reset by gap, then win → 1
+    expect(stats.streak).toBe(1);
+    expect(stats.lastPlayedDate).toBe("2026-04-20");
+    expect(stats.longestStreak).toBe(5);
+  });
+
+  it("does not infer when played is 0", () => {
+    // Fresh user, no stats → no scan, no noise
+    localStorage.setItem(
+      DAILY_RESULT_PREFIX + "2026-04-15",
+      JSON.stringify({ date: "2026-04-15", status: "won", attempts: 3 })
+    );
+    const stats = loadStats("2026-04-20");
+    expect(stats.lastPlayedDate).toBeUndefined();
+    expect(stats.streak).toBe(0);
   });
 });

--- a/src/__tests__/guessStats.test.ts
+++ b/src/__tests__/guessStats.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { loadStats, recordResult } from "../pages/GuessThePlayer/helpers";
+import { STATS_KEY } from "../pages/GuessThePlayer/constants";
+
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  const shim = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  };
+  vi.stubGlobal("localStorage", shim);
+}
+
+describe("recordResult — streak with date gaps", () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it("increments streak on consecutive daily wins", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    const stats = recordResult(true, "2026-04-17");
+    expect(stats.streak).toBe(3);
+    expect(stats.longestStreak).toBe(3);
+  });
+
+  it("resets streak to 1 after a skipped day, then win", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    // skip 2026-04-17, play 2026-04-18
+    const stats = recordResult(true, "2026-04-18");
+    expect(stats.streak).toBe(1);
+  });
+
+  it("preserves longestStreak across a broken streak", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    recordResult(true, "2026-04-17"); // streak=3
+    // skip 2 days
+    const stats = recordResult(true, "2026-04-20");
+    expect(stats.streak).toBe(1);
+    expect(stats.longestStreak).toBe(3);
+  });
+
+  it("resets streak to 0 on a loss", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    const stats = recordResult(false, "2026-04-17");
+    expect(stats.streak).toBe(0);
+  });
+
+  it("first play ever yields streak=1 on win", () => {
+    const stats = recordResult(true, "2026-04-15");
+    expect(stats.streak).toBe(1);
+    expect(stats.longestStreak).toBe(1);
+  });
+
+  it("records lastPlayedDate on each play", () => {
+    recordResult(true, "2026-04-15");
+    const stats = recordResult(false, "2026-04-16");
+    expect(stats.lastPlayedDate).toBe("2026-04-16");
+  });
+});
+
+describe("loadStats — display-time stale streak", () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it("shows streak as 0 when last played date is more than 1 day ago", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16"); // streak=2, last=2026-04-16
+    // user opens the app on 2026-04-20 without playing
+    const stats = loadStats("2026-04-20");
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(2);
+  });
+
+  it("keeps streak intact when viewed on the same day", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    const stats = loadStats("2026-04-16");
+    expect(stats.streak).toBe(2);
+  });
+
+  it("keeps streak intact when viewed the day after last play", () => {
+    recordResult(true, "2026-04-15");
+    recordResult(true, "2026-04-16");
+    const stats = loadStats("2026-04-17");
+    expect(stats.streak).toBe(2);
+  });
+
+  it("returns defaults when no stats stored", () => {
+    const stats = loadStats("2026-04-20");
+    expect(stats.played).toBe(0);
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(0);
+  });
+
+  it("preserves legacy stats without lastPlayedDate", () => {
+    // Simulate a pre-fix stats blob with no lastPlayedDate
+    localStorage.setItem(
+      STATS_KEY,
+      JSON.stringify({ played: 5, won: 4, lost: 1, streak: 4, longestStreak: 4 })
+    );
+    const stats = loadStats("2026-04-20");
+    // No lastPlayedDate means we can't detect a gap — show as-is
+    expect(stats.streak).toBe(4);
+    expect(stats.longestStreak).toBe(4);
+  });
+});

--- a/src/pages/GuessThePlayer/helpers.ts
+++ b/src/pages/GuessThePlayer/helpers.ts
@@ -102,18 +102,31 @@ export function mergeConsecutiveClubs(clubs: FormerTeam[]): MergedClub[] {
 
 const DEFAULT_STATS: GuessStats = { played: 0, won: 0, lost: 0, streak: 0, longestStreak: 0 };
 
-export function loadStats(): GuessStats {
+function daysBetween(from: string, to: string): number {
+  const toUTC = (s: string) => {
+    const [y, m, d] = s.split("-").map(Number);
+    return Date.UTC(y, m - 1, d);
+  };
+  return Math.round((toUTC(to) - toUTC(from)) / 86_400_000);
+}
+
+export function loadStats(today: string = getTodayString()): GuessStats {
   try {
     const stored = localStorage.getItem(STATS_KEY);
-    if (!stored) return { ...DEFAULT_STATS };
-    return { ...DEFAULT_STATS, ...JSON.parse(stored) };
+    const stats: GuessStats = stored
+      ? { ...DEFAULT_STATS, ...JSON.parse(stored) }
+      : { ...DEFAULT_STATS };
+    if (stats.streak > 0 && stats.lastPlayedDate && daysBetween(stats.lastPlayedDate, today) > 1) {
+      stats.streak = 0;
+    }
+    return stats;
   } catch {
     return { ...DEFAULT_STATS };
   }
 }
 
-export function recordResult(won: boolean): GuessStats {
-  const stats = loadStats();
+export function recordResult(won: boolean, today: string = getTodayString()): GuessStats {
+  const stats = loadStats(today);
   stats.played++;
   if (won) {
     stats.won++;
@@ -125,6 +138,7 @@ export function recordResult(won: boolean): GuessStats {
     stats.lost++;
     stats.streak = 0;
   }
+  stats.lastPlayedDate = today;
   localStorage.setItem(STATS_KEY, JSON.stringify(stats));
   return stats;
 }

--- a/src/pages/GuessThePlayer/helpers.ts
+++ b/src/pages/GuessThePlayer/helpers.ts
@@ -1,5 +1,7 @@
 import { SEED_PLAYERS } from "../../data/seedPlayers";
 import { DAILY_GUESS_KEY, DAILY_RESULT_PREFIX, DAY_ONE_DATE, STATS_KEY } from "./constants";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 import type { DailyResult, GuessStats } from "./types";
 import type { FormerTeam } from "../../types";
 import type { MergedClub } from "../../components/PlayerCard/types";
@@ -110,12 +112,43 @@ function daysBetween(from: string, to: string): number {
   return Math.round((toUTC(to) - toUTC(from)) / 86_400_000);
 }
 
+// Legacy stats (pre-fix) have no lastPlayedDate. Recover it by scanning the
+// per-date daily result keys for the most recent play — so existing users
+// get correct gap detection on their first post-deploy play.
+function inferLastPlayedDate(): string | undefined {
+  let latest: string | undefined;
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith(DAILY_RESULT_PREFIX)) continue;
+      const date = key.slice(DAILY_RESULT_PREFIX.length);
+      if (!ISO_DATE.test(date)) continue;
+      if (!latest || date > latest) latest = date;
+    }
+    if (!latest) {
+      const legacy = localStorage.getItem(DAILY_GUESS_KEY);
+      if (legacy) {
+        const parsed = JSON.parse(legacy);
+        if (typeof parsed?.date === "string" && ISO_DATE.test(parsed.date)) {
+          latest = parsed.date;
+        }
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return latest;
+}
+
 export function loadStats(today: string = getTodayString()): GuessStats {
   try {
     const stored = localStorage.getItem(STATS_KEY);
     const stats: GuessStats = stored
       ? { ...DEFAULT_STATS, ...JSON.parse(stored) }
       : { ...DEFAULT_STATS };
+    if (!stats.lastPlayedDate && stats.played > 0) {
+      stats.lastPlayedDate = inferLastPlayedDate();
+    }
     if (stats.streak > 0 && stats.lastPlayedDate && daysBetween(stats.lastPlayedDate, today) > 1) {
       stats.streak = 0;
     }

--- a/src/pages/GuessThePlayer/types.ts
+++ b/src/pages/GuessThePlayer/types.ts
@@ -43,4 +43,5 @@ export interface GuessStats {
   lost: number;
   streak: number;
   longestStreak: number;
+  lastPlayedDate?: string;
 }

--- a/src/pages/GuessThePlayer/useGuessGame.ts
+++ b/src/pages/GuessThePlayer/useGuessGame.ts
@@ -27,7 +27,7 @@ export function useGuessGame() {
   const [today] = useState(getTodayString);
   const [dailyResult] = useState(getDailyResult);
   const alreadyPlayedToday = dailyResult?.date === today;
-  const [stats, setStats] = useState<GuessStats>(loadStats);
+  const [stats, setStats] = useState<GuessStats>(() => loadStats(today));
 
   const [state, setState] = useState<GuessGameState>(() => ({
     targetPlayer: null,
@@ -171,7 +171,7 @@ export function useGuessGame() {
         const finalAttempts = state.attempts + 1;
         if (state.isDaily) {
           saveDailyResult("won", finalAttempts);
-          setStats(recordResult(true));
+          setStats(recordResult(true, today));
           submitDailyResult(today, true, finalAttempts);
         } else if (state.isArchive && state.dayNumber) {
           // Save archive result per-date but don't affect stats/streak
@@ -186,7 +186,7 @@ export function useGuessGame() {
         if (newAttempts >= MAX_ATTEMPTS) {
           if (state.isDaily) {
             saveDailyResult("lost", newAttempts);
-            setStats(recordResult(false));
+            setStats(recordResult(false, today));
             submitDailyResult(today, false, newAttempts);
           } else if (state.isArchive && state.dayNumber) {
             const archiveDate = getDateForDay(state.dayNumber);
@@ -221,7 +221,7 @@ export function useGuessGame() {
     if (newAttempts >= MAX_ATTEMPTS) {
       if (state.isDaily) {
         saveDailyResult("lost", newAttempts);
-        setStats(recordResult(false));
+        setStats(recordResult(false, today));
         submitDailyResult(today, false, newAttempts);
       } else if (state.isArchive && state.dayNumber) {
         const archiveDate = getDateForDay(state.dayNumber);


### PR DESCRIPTION
## Summary
- Streak counter ignored skipped days — missing a day only broke the streak if you actually played and lost.
- Now tracks `lastPlayedDate` in `GuessStats` and resets streak to 0 when the gap between last play and today exceeds 1 day.
- Applied at both record time (`recordResult`) and display time (`loadStats`) so the UI shows the correct streak even before you play today's puzzle.

## Notes
- Backwards-compat safe: `lastPlayedDate` is optional and merges over `DEFAULT_STATS`. Users with pre-fix stats will miss gap detection on their first post-fix play; their next play stamps the date and gap logic kicks in from then on.
- `longestStreak` is preserved across gap-breaks — only the current `streak` resets.

## Test plan
- [x] Unit tests cover consecutive wins, skipped-day reset, longestStreak preservation, loss reset, first-play, legacy stats without `lastPlayedDate`, and display-time staleness (11 new tests).
- [x] `npm test` — 59 passed
- [x] `npm run build` — clean
- [ ] Manual: verify existing user's stale streak (7/7) displays as 0 after loading the page, becomes 1 after winning today's puzzle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)