### PR TITLE
feat: admin can add and edit clubs in player history

### DIFF
--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -169,6 +169,16 @@ export async function updatePlayerClubLoan(
   return !error;
 }
 
+export async function deletePlayerClub(playerClubId: number): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("player_clubs")
+    .delete()
+    .eq("id", playerClubId);
+  if (error) console.error("deletePlayerClub failed:", error);
+  return !error;
+}
+
 export async function updatePlayerClubYears(
   playerClubId: number,
   yearJoined: string,
@@ -193,13 +203,22 @@ export async function addPlayerClub(
 
   const { data: existing } = await supabase
     .from("player_clubs")
-    .select("sort_order")
+    .select("id, sort_order, year_joined")
     .eq("player_id", playerId)
-    .order("sort_order", { ascending: false, nullsFirst: false })
-    .limit(1);
-  const nextSortOrder = existing && existing.length > 0 && existing[0].sort_order != null
-    ? existing[0].sort_order + 1
-    : 0;
+    .order("sort_order", { ascending: true, nullsFirst: false })
+    .order("year_joined", { ascending: true });
+
+  const rows = existing ?? [];
+  const hasNulls = rows.some((r) => r.sort_order == null);
+  if (hasNulls) {
+    for (let i = 0; i < rows.length; i++) {
+      await supabase
+        .from("player_clubs")
+        .update({ sort_order: i })
+        .eq("id", rows[i].id);
+    }
+  }
+  const nextSortOrder = rows.length;
 
   const { data, error } = await supabase
     .from("player_clubs")

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -169,6 +169,79 @@ export async function updatePlayerClubLoan(
   return !error;
 }
 
+export async function updatePlayerClubYears(
+  playerClubId: number,
+  yearJoined: string,
+  yearDeparted: string,
+): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase
+    .from("player_clubs")
+    .update({ year_joined: yearJoined, year_departed: yearDeparted })
+    .eq("id", playerClubId);
+  if (error) console.error("updatePlayerClubYears failed:", error);
+  return !error;
+}
+
+export async function addPlayerClub(
+  playerId: string,
+  clubId: string,
+  yearJoined: string,
+  yearDeparted: string,
+): Promise<AdminClubRow | null> {
+  if (!supabase) return null;
+
+  const { data: existing } = await supabase
+    .from("player_clubs")
+    .select("sort_order")
+    .eq("player_id", playerId)
+    .order("sort_order", { ascending: false, nullsFirst: false })
+    .limit(1);
+  const nextSortOrder = existing && existing.length > 0 && existing[0].sort_order != null
+    ? existing[0].sort_order + 1
+    : 0;
+
+  const { data, error } = await supabase
+    .from("player_clubs")
+    .insert({
+      player_id: playerId,
+      club_id: clubId,
+      year_joined: yearJoined,
+      year_departed: yearDeparted,
+      sort_order: nextSortOrder,
+    })
+    .select("id, club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(name, badge)")
+    .single();
+  if (error || !data) {
+    console.error("addPlayerClub failed:", error);
+    return null;
+  }
+
+  const row = data as unknown as {
+    id: number;
+    club_id: string;
+    year_joined: string;
+    year_departed: string;
+    is_hidden: boolean;
+    is_youth_team: boolean;
+    is_loan: boolean;
+    sort_order: number | null;
+    clubs: { name: string; badge: string } | null;
+  };
+  return {
+    id: row.id,
+    club_id: row.club_id,
+    club_name: row.clubs?.name ?? row.club_id,
+    badge: row.clubs?.badge ?? "",
+    year_joined: row.year_joined,
+    year_departed: row.year_departed,
+    is_hidden: row.is_hidden,
+    is_youth_team: row.is_youth_team,
+    is_loan: row.is_loan,
+    sort_order: row.sort_order,
+  };
+}
+
 // --- Club reorder operations ---
 
 export async function updateClubSortOrders(

--- a/src/pages/Admin/AddClubForm.tsx
+++ b/src/pages/Admin/AddClubForm.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef, useState } from "react";
+import { addPlayerClub, searchClubs } from "../../api/adminApi";
+import type { AdminClubRow } from "./types";
+
+interface Props {
+  playerId: string;
+  onAdded: (row: AdminClubRow) => void;
+}
+
+interface ClubHit {
+  id: string;
+  name: string;
+  badge: string;
+}
+
+export default function AddClubForm({ playerId, onAdded }: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ClubHit[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<ClubHit | null>(null);
+  const [yearJoined, setYearJoined] = useState("");
+  const [yearDeparted, setYearDeparted] = useState("");
+  const [isPresent, setIsPresent] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    setSelected(null);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (value.trim().length < 2) {
+      setResults([]);
+      setIsOpen(false);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      const hits = await searchClubs(value.trim());
+      setResults(hits);
+      setIsOpen(hits.length > 0);
+    }, 250);
+  }
+
+  function pickClub(club: ClubHit) {
+    setSelected(club);
+    setQuery(club.name);
+    setIsOpen(false);
+  }
+
+  function reset() {
+    setQuery("");
+    setResults([]);
+    setSelected(null);
+    setYearJoined("");
+    setYearDeparted("");
+    setIsPresent(false);
+    setError(null);
+  }
+
+  async function handleAdd() {
+    setError(null);
+    if (!selected) {
+      setError("Pick a club from the list.");
+      return;
+    }
+    if (!/^\d{4}$/.test(yearJoined)) {
+      setError("Year joined must be a 4-digit year.");
+      return;
+    }
+    const departed = isPresent ? "" : yearDeparted;
+    if (!isPresent && !/^\d{4}$/.test(departed)) {
+      setError("Year departed must be a 4-digit year, or check Present.");
+      return;
+    }
+    setSaving(true);
+    const row = await addPlayerClub(playerId, selected.id, yearJoined, departed);
+    setSaving(false);
+    if (!row) {
+      setError("Failed to add club. It may already exist for this player+year.");
+      return;
+    }
+    onAdded(row);
+    reset();
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-gray-700 space-y-2">
+      <p className="text-xs text-gray-500">Add a club</p>
+      <div ref={containerRef} className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          placeholder="Search club..."
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 text-sm focus:outline-none focus:border-green-500"
+        />
+        {isOpen && results.length > 0 && (
+          <ul className="absolute z-10 mt-1 w-full bg-gray-800 border border-gray-600 rounded-lg overflow-hidden shadow-lg max-h-64 overflow-y-auto">
+            {results.map((club) => (
+              <li key={club.id}>
+                <button
+                  type="button"
+                  onClick={() => pickClub(club)}
+                  className="w-full px-3 py-2 flex items-center gap-2 text-left text-sm hover:bg-gray-700 transition-colors"
+                >
+                  {club.badge && (
+                    <img
+                      src={club.badge}
+                      alt=""
+                      className="w-6 h-6 object-contain bg-gray-700 rounded"
+                    />
+                  )}
+                  <span className="text-white">{club.name}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          inputMode="numeric"
+          maxLength={4}
+          value={yearJoined}
+          onChange={(e) => setYearJoined(e.target.value.replace(/\D/g, ""))}
+          placeholder="Joined"
+          className="w-20 px-2 py-1.5 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 text-sm focus:outline-none focus:border-green-500"
+        />
+        <span className="text-gray-500 text-sm">–</span>
+        <input
+          type="text"
+          inputMode="numeric"
+          maxLength={4}
+          value={isPresent ? "" : yearDeparted}
+          disabled={isPresent}
+          onChange={(e) => setYearDeparted(e.target.value.replace(/\D/g, ""))}
+          placeholder="Departed"
+          className="w-20 px-2 py-1.5 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 text-sm focus:outline-none focus:border-green-500 disabled:opacity-50"
+        />
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPresent}
+            onChange={(e) => setIsPresent(e.target.checked)}
+            className="accent-green-500 w-3.5 h-3.5"
+          />
+          <span className="text-xs text-gray-300">Present</span>
+        </label>
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={saving || !selected || !yearJoined}
+          className="ml-auto px-3 py-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          {saving ? "Adding..." : "Add"}
+        </button>
+      </div>
+
+      {error && <p className="text-red-400 text-xs">{error}</p>}
+    </div>
+  );
+}

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -6,6 +6,7 @@ import {
   updatePlayerClubYouthTeam,
   updatePlayerClubLoan,
   updatePlayerClubYears,
+  deletePlayerClub,
   updatePlayerLegacy,
   updateClubSortOrders,
   updateClubName,
@@ -173,6 +174,15 @@ export default function PlayerClubList({ playerId }: Props) {
 
   function handleClubAdded(row: AdminClubRow) {
     setClubs((prev) => [...prev, row]);
+  }
+
+  async function handleDelete(club: AdminClubRow) {
+    const ok = window.confirm(`Delete ${club.club_name} (${club.year_joined || "?"}–${club.year_departed || "present"}) from this player's history?`);
+    if (!ok) return;
+    const deleted = await deletePlayerClub(club.id);
+    if (deleted) {
+      setClubs((prev) => prev.filter((c) => c.id !== club.id));
+    }
   }
 
   if (loading) {
@@ -357,6 +367,18 @@ export default function PlayerClubList({ playerId }: Props) {
                   d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
             )}
+          </button>
+
+          {/* Delete */}
+          <button
+            onClick={() => handleDelete(club)}
+            title="Delete this club from the player's history"
+            className="p-1.5 rounded text-gray-500 hover:text-red-400 hover:bg-gray-700 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+            </svg>
           </button>
         </div>
       ))}

--- a/src/pages/Admin/PlayerClubList.tsx
+++ b/src/pages/Admin/PlayerClubList.tsx
@@ -5,12 +5,14 @@ import {
   updatePlayerClubHidden,
   updatePlayerClubYouthTeam,
   updatePlayerClubLoan,
+  updatePlayerClubYears,
   updatePlayerLegacy,
   updateClubSortOrders,
   updateClubName,
 } from "../../api/adminApi";
 import type { AdminClubRow } from "./types";
 import CrestDropZone from "./CrestDropZone";
+import AddClubForm from "./AddClubForm";
 
 interface Props {
   playerId: string;
@@ -21,6 +23,9 @@ export default function PlayerClubList({ playerId }: Props) {
   const [loading, setLoading] = useState(true);
   const [editingNameId, setEditingNameId] = useState<number | null>(null);
   const [editNameValue, setEditNameValue] = useState("");
+  const [editingYearsId, setEditingYearsId] = useState<number | null>(null);
+  const [editYearJoined, setEditYearJoined] = useState("");
+  const [editYearDeparted, setEditYearDeparted] = useState("");
   const [legacyOverride, setLegacyOverride] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -125,12 +130,62 @@ export default function PlayerClubList({ playerId }: Props) {
     }
   }
 
+  function startEditYears(club: AdminClubRow) {
+    setEditingYearsId(club.id);
+    setEditYearJoined(club.year_joined || "");
+    setEditYearDeparted(club.year_departed || "");
+  }
+
+  async function saveEditYears(club: AdminClubRow) {
+    const joined = editYearJoined.trim();
+    const departed = editYearDeparted.trim();
+    if (joined && !/^\d{4}$/.test(joined)) {
+      setEditingYearsId(null);
+      return;
+    }
+    if (departed && !/^\d{4}$/.test(departed)) {
+      setEditingYearsId(null);
+      return;
+    }
+    if (joined === club.year_joined && departed === club.year_departed) {
+      setEditingYearsId(null);
+      return;
+    }
+    const ok = await updatePlayerClubYears(club.id, joined, departed);
+    if (ok) {
+      setClubs((prev) =>
+        prev.map((c) =>
+          c.id === club.id ? { ...c, year_joined: joined, year_departed: departed } : c,
+        ),
+      );
+    }
+    setEditingYearsId(null);
+  }
+
+  function handleYearsKeyDown(e: React.KeyboardEvent, club: AdminClubRow) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveEditYears(club);
+    } else if (e.key === "Escape") {
+      setEditingYearsId(null);
+    }
+  }
+
+  function handleClubAdded(row: AdminClubRow) {
+    setClubs((prev) => [...prev, row]);
+  }
+
   if (loading) {
     return <p className="text-gray-500 text-sm py-2">Loading clubs...</p>;
   }
 
   if (clubs.length === 0) {
-    return <p className="text-gray-500 text-sm py-2">No club history found.</p>;
+    return (
+      <div className="space-y-2">
+        <p className="text-gray-500 text-sm py-2">No club history found.</p>
+        <AddClubForm playerId={playerId} onAdded={handleClubAdded} />
+      </div>
+    );
   }
 
   const lastYear = String(new Date().getFullYear() - 1);
@@ -220,9 +275,41 @@ export default function PlayerClubList({ playerId }: Props) {
                 {club.club_name}
               </button>
             )}
-            <div className="text-xs text-gray-500">
-              {club.year_joined || "?"} – {club.year_departed || "present"}
-            </div>
+            {editingYearsId === club.id ? (
+              <div className="flex items-center gap-1 mt-0.5">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={4}
+                  value={editYearJoined}
+                  onChange={(e) => setEditYearJoined(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => handleYearsKeyDown(e, club)}
+                  className="w-16 px-1.5 py-0.5 text-xs bg-gray-700 text-white rounded border border-gray-500 focus:outline-none focus:border-green-500"
+                  placeholder="YYYY"
+                  autoFocus
+                />
+                <span className="text-xs text-gray-500">–</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={4}
+                  value={editYearDeparted}
+                  onChange={(e) => setEditYearDeparted(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => handleYearsKeyDown(e, club)}
+                  onBlur={() => saveEditYears(club)}
+                  className="w-16 px-1.5 py-0.5 text-xs bg-gray-700 text-white rounded border border-gray-500 focus:outline-none focus:border-green-500"
+                  placeholder="present"
+                />
+              </div>
+            ) : (
+              <button
+                onClick={() => startEditYears(club)}
+                className="text-xs text-gray-500 hover:text-white hover:underline cursor-text"
+                title="Click to edit years"
+              >
+                {club.year_joined || "?"} – {club.year_departed || "present"}
+              </button>
+            )}
           </div>
 
           {/* Flags */}
@@ -273,6 +360,7 @@ export default function PlayerClubList({ playerId }: Props) {
           </button>
         </div>
       ))}
+      <AddClubForm playerId={playerId} onAdded={handleClubAdded} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Admins can append clubs to a player's history from the schedule expander — club autocomplete, year joined/departed, and a Present toggle for current spells.
- Existing rows now have click-to-edit years inline (blank departed = "present").
- New `addPlayerClub` and `updatePlayerClubYears` APIs; new row is inserted with `sort_order = max + 1` so it lands at the end.

## Motivation
Some players have outdated club histories, which made them unusable as daily puzzles. This unblocks curation without a re-import.

## Test plan
- [x] Expand a player in the admin schedule — edit a club's years inline (save on Enter / blur).
- [x] Add a new club via search → pick → enter years → Add. Verify it appears at the bottom of the list.
- [ ] Tick "Present", add, confirm `year_departed` is saved as empty and card renders "present".
- [ ] Try adding the same club+join-year twice — expect the unique-constraint error surfaced in the form.
- [x] Verify the new row's sort_order puts it last, and reorder arrows still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)