### PR TITLE
feat: pack mode tracer (slice 01)

### DIFF
--- a/e2e/pack-tracer.spec.ts
+++ b/e2e/pack-tracer.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack Mode (tracer)", () => {
+  test("renders today's seeded pack with club header, photo, autocomplete, and 10-dot strip", async ({ page }) => {
+    await page.goto("/#/pack");
+
+    const search = page.getByPlaceholder("Player name");
+    const idleAlert = page.getByRole("alert");
+
+    const outcome = await Promise.race([
+      search.waitFor({ state: "visible", timeout: 15_000 }).then(() => "playing" as const).catch(() => null),
+      idleAlert.waitFor({ state: "visible", timeout: 15_000 }).then(() => "idle" as const).catch(() => null),
+    ]);
+
+    if (outcome === "idle") {
+      test.skip(true, "No pack seeded for today — migration not run.");
+      return;
+    }
+
+    expect(outcome).toBe("playing");
+    await expect(page.getByRole("list", { name: "Pack progress" })).toBeVisible();
+    await expect(page.getByRole("listitem")).toHaveCount(10);
+    await expect(page.getByText(/Player\s+1\s*\/\s*10/)).toBeVisible();
+    await expect(page.getByText(/Score:/)).toBeVisible();
+  });
+
+  test("submitting a wrong guess increments the guess counter", async ({ page }) => {
+    await page.goto("/#/pack");
+
+    const search = page.getByPlaceholder("Player name");
+    const ready = await search.waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today — migration not run.");
+      return;
+    }
+
+    await expect(page.getByText(/Guesses:.*0.*\/.*3/)).toBeVisible();
+
+    await search.fill("Wayne Rooney");
+    const option = page.getByRole("option").first();
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.click();
+
+    // Either it's the answer (advances to player 2) or it's wrong (counter ticks).
+    await expect(async () => {
+      const onSecond = await page.getByText(/Player\s+2\s*\/\s*10/).isVisible();
+      const wrongTick = await page.getByText(/Guesses:.*1.*\/.*3/).isVisible();
+      const reveal = await page.getByText("Out of guesses").isVisible();
+      expect(onSecond || wrongTick || reveal).toBe(true);
+    }).toPass({ timeout: 5_000 });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Battle from "./pages/Battle";
 import GuessThePlayer from "./pages/GuessThePlayer";
 import GuessArchive from "./pages/GuessThePlayer/Archive";
 import MultiplayerBattle from "./pages/MultiplayerBattle";
+import Pack from "./pages/Pack";
 
 const Admin = lazy(() => import("./pages/Admin"));
 
@@ -17,6 +18,7 @@ function App() {
         <Route path="/battle/multiplayer" element={<MultiplayerBattle />} />
         <Route path="/guess" element={<GuessThePlayer />} />
         <Route path="/guess/archive" element={<GuessArchive />} />
+        <Route path="/pack" element={<Pack />} />
         <Route path="/admin" element={<Suspense fallback={null}><Admin /></Suspense>} />
       </Routes>
     </HashRouter>

--- a/src/__tests__/packGameLogic.test.ts
+++ b/src/__tests__/packGameLogic.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { initialState, submitGuess, advance } from "../pages/Pack/gameLogic";
+import type { PackData } from "../pages/Pack/types";
+import type { Player, PlayerWithTeams } from "../types";
+
+function makePlayer(id: string, name: string): PlayerWithTeams {
+  return {
+    id,
+    name,
+    thumbnail: `https://example.com/${id}.jpg`,
+    nationality: "Brazil",
+    formerTeams: [
+      { teamId: "club-1", teamName: "Test FC", yearJoined: "2020", yearDeparted: "2024", badge: "" },
+    ],
+  };
+}
+
+function makePack(playerCount = 10): PackData {
+  return {
+    date: "2026-05-04",
+    club: { id: "club-1", name: "Test FC", badge: "" },
+    players: Array.from({ length: playerCount }, (_, i) => makePlayer(`p${i + 1}`, `Player ${i + 1}`)),
+  };
+}
+
+function asGuess(p: PlayerWithTeams): Player {
+  return { id: p.id, name: p.name, thumbnail: p.thumbnail, nationality: p.nationality };
+}
+
+describe("pack gameLogic — initial state", () => {
+  it("starts at index 0 with score 0 and status 'playing' once a pack is loaded", () => {
+    const state = initialState(makePack());
+    expect(state.currentIndex).toBe(0);
+    expect(state.score).toBe(0);
+    expect(state.guessesForCurrent).toBe(0);
+    expect(state.wrongGuessesForCurrent).toEqual([]);
+    expect(state.status).toBe("playing");
+    expect(state.attempts).toEqual([]);
+  });
+});
+
+describe("pack gameLogic — wrong guess", () => {
+  it("stays on the same player and records the wrong guess", () => {
+    const pack = makePack();
+    const wrong: Player = { id: "intruder", name: "Wrong Guy", thumbnail: "", nationality: "" };
+    const next = submitGuess(initialState(pack), wrong);
+
+    expect(next.status).toBe("playing");
+    expect(next.currentIndex).toBe(0);
+    expect(next.guessesForCurrent).toBe(1);
+    expect(next.wrongGuessesForCurrent).toEqual([wrong]);
+    expect(next.score).toBe(0);
+    expect(next.attempts).toEqual([]);
+  });
+});
+
+describe("pack gameLogic — third wrong guess", () => {
+  it("transitions to 'revealing' and records the attempt as failed without scoring", () => {
+    const pack = makePack();
+    const wrong: Player = { id: "w1", name: "Wrong One", thumbnail: "", nationality: "" };
+    let state = initialState(pack);
+    state = submitGuess(state, wrong);
+    state = submitGuess(state, wrong);
+    state = submitGuess(state, wrong);
+
+    expect(state.status).toBe("revealing");
+    expect(state.score).toBe(0);
+    expect(state.guessesForCurrent).toBe(3);
+    expect(state.attempts).toEqual([{ playerId: "p1", correct: false, guesses: 3 }]);
+  });
+});
+
+describe("pack gameLogic — guards", () => {
+  it("ignores guesses while revealing", () => {
+    const pack = makePack();
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    const after = submitGuess(state, asGuess(pack.players[1]));
+    expect(after).toBe(state);
+  });
+
+  it("ignores guesses when finished", () => {
+    const pack = makePack(1);
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    state = advance(state);
+    expect(state.status).toBe("finished");
+    const after = submitGuess(state, asGuess(pack.players[0]));
+    expect(after).toBe(state);
+  });
+});
+
+describe("pack gameLogic — advance", () => {
+  it("moves to the next player and clears per-player state", () => {
+    const pack = makePack();
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    expect(state.status).toBe("revealing");
+
+    const next = advance(state);
+    expect(next.status).toBe("playing");
+    expect(next.currentIndex).toBe(1);
+    expect(next.guessesForCurrent).toBe(0);
+    expect(next.wrongGuessesForCurrent).toEqual([]);
+    expect(next.score).toBe(1);
+  });
+
+  it("transitions to 'finished' after the last player", () => {
+    const pack = makePack(2);
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    state = advance(state);
+    state = submitGuess(state, asGuess(pack.players[1]));
+    state = advance(state);
+
+    expect(state.status).toBe("finished");
+    expect(state.score).toBe(2);
+    expect(state.attempts).toHaveLength(2);
+  });
+});
+
+describe("pack gameLogic — correct guess", () => {
+  it("transitions to 'revealing', increments score, and records the attempt", () => {
+    const pack = makePack();
+    const state = initialState(pack);
+    const next = submitGuess(state, asGuess(pack.players[0]));
+
+    expect(next.status).toBe("revealing");
+    expect(next.score).toBe(1);
+    expect(next.attempts).toHaveLength(1);
+    expect(next.attempts[0]).toEqual({ playerId: "p1", correct: true, guesses: 1 });
+    expect(next.currentIndex).toBe(0);
+  });
+});

--- a/src/api/packSchedule.ts
+++ b/src/api/packSchedule.ts
@@ -1,0 +1,34 @@
+import { supabase } from "./supabaseClient";
+import { getFromCacheById } from "./playerCache";
+import type { PackData } from "../pages/Pack/types";
+
+interface PackScheduleRow {
+  date: string;
+  club_id: string;
+  player_ids: string[];
+  clubs: { id: string; name: string; badge: string } | null;
+}
+
+export async function getPackForDate(date: string): Promise<PackData | null> {
+  if (!supabase) return null;
+
+  const { data, error } = await supabase
+    .from("pack_schedule")
+    .select("date, club_id, player_ids, clubs(id, name, badge)")
+    .eq("date", date)
+    .single();
+
+  if (error || !data) return null;
+  const row = data as unknown as PackScheduleRow;
+  if (!row.clubs) return null;
+
+  const players = await Promise.all(row.player_ids.map((id) => getFromCacheById(id)));
+  const valid = players.filter((p): p is NonNullable<typeof p> => p !== null);
+  if (valid.length === 0) return null;
+
+  return {
+    date: row.date,
+    club: { id: row.clubs.id, name: row.clubs.name, badge: row.clubs.badge },
+    players: valid,
+  };
+}

--- a/src/components/PlayerSearch/index.tsx
+++ b/src/components/PlayerSearch/index.tsx
@@ -3,7 +3,7 @@ import { searchPlayers } from "../../api/playerCache";
 import type { Player } from "../../types";
 import type { PlayerSearchProps } from "./types";
 
-export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, disabledPlayerIds, placeholder }: PlayerSearchProps) {
+export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, disabledPlayerIds, placeholder, hideThumbnails }: PlayerSearchProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Player[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -151,7 +151,7 @@ export default function PlayerSearch({ onSelect, disabled, usedPlayerIds, disabl
                     : index === highlightIndex ? "bg-gray-700" : "hover:bg-gray-700"
                 }`}
               >
-                {player.thumbnail && (
+                {!hideThumbnails && player.thumbnail && (
                   <img
                     src={player.thumbnail}
                     alt=""

--- a/src/components/PlayerSearch/types.ts
+++ b/src/components/PlayerSearch/types.ts
@@ -6,4 +6,5 @@ export interface PlayerSearchProps {
   usedPlayerIds?: Set<string>;
   disabledPlayerIds?: Map<string, string>;  // id → reason label (shown but not selectable)
   placeholder?: string;
+  hideThumbnails?: boolean;
 }

--- a/src/pages/Pack/constants.ts
+++ b/src/pages/Pack/constants.ts
@@ -1,0 +1,2 @@
+export const PACK_SIZE = 10;
+export const MAX_GUESSES_PER_PLAYER = 3;

--- a/src/pages/Pack/gameLogic.ts
+++ b/src/pages/Pack/gameLogic.ts
@@ -1,0 +1,67 @@
+import type { Player } from "../../types";
+import type { PackData, PackGameState } from "./types";
+import { MAX_GUESSES_PER_PLAYER } from "./constants";
+
+export function initialState(pack: PackData): PackGameState {
+  return {
+    pack,
+    currentIndex: 0,
+    guessesForCurrent: 0,
+    wrongGuessesForCurrent: [],
+    status: "playing",
+    attempts: [],
+    score: 0,
+    error: null,
+  };
+}
+
+function isCorrect(state: PackGameState, guess: Player): boolean {
+  const target = state.pack?.players[state.currentIndex];
+  if (!target) return false;
+  return guess.id === target.id || guess.name.toLowerCase() === target.name.toLowerCase();
+}
+
+export function submitGuess(state: PackGameState, guess: Player): PackGameState {
+  if (!state.pack || state.status !== "playing") return state;
+  const target = state.pack.players[state.currentIndex];
+  const guesses = state.guessesForCurrent + 1;
+  if (isCorrect(state, guess)) {
+    return {
+      ...state,
+      status: "revealing",
+      guessesForCurrent: guesses,
+      score: state.score + 1,
+      attempts: [...state.attempts, { playerId: target.id, correct: true, guesses }],
+    };
+  }
+  const wrongGuesses = [...state.wrongGuessesForCurrent, guess];
+  if (guesses >= MAX_GUESSES_PER_PLAYER) {
+    return {
+      ...state,
+      status: "revealing",
+      guessesForCurrent: guesses,
+      wrongGuessesForCurrent: wrongGuesses,
+      attempts: [...state.attempts, { playerId: target.id, correct: false, guesses }],
+    };
+  }
+  return {
+    ...state,
+    guessesForCurrent: guesses,
+    wrongGuessesForCurrent: wrongGuesses,
+  };
+}
+
+export function advance(state: PackGameState): PackGameState {
+  if (!state.pack || state.status !== "revealing") return state;
+  const nextIndex = state.currentIndex + 1;
+  if (nextIndex >= state.pack.players.length) {
+    return { ...state, status: "finished" };
+  }
+  return {
+    ...state,
+    status: "playing",
+    currentIndex: nextIndex,
+    guessesForCurrent: 0,
+    wrongGuessesForCurrent: [],
+  };
+}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -1,0 +1,120 @@
+import { Link } from "react-router-dom";
+import { usePackGame } from "./usePackGame";
+import PlayerSearch from "../../components/PlayerSearch";
+import { MAX_GUESSES_PER_PLAYER } from "./constants";
+
+export default function Pack() {
+  const { state, submitGuess } = usePackGame();
+  const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
+  const currentPlayer = pack?.players[currentIndex] ?? null;
+  const lastAttempt = attempts[attempts.length - 1];
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white flex flex-col">
+      <header className="py-6 border-b border-gray-700">
+        <h1 className="text-3xl font-bold text-center">Football Nerdle</h1>
+        <p className="text-gray-400 text-center mt-1">
+          Pack Mode {pack ? `— ${pack.club.name}` : ""}
+        </p>
+        <div className="flex items-center justify-center gap-4 mt-2">
+          <Link to="/" className="text-green-400 hover:text-green-300 text-sm">← Back to Home</Link>
+        </div>
+      </header>
+
+      <main className="flex-1 flex flex-col items-center px-4 py-8 gap-6">
+        {status === "loading" && <p className="text-gray-400">Loading pack...</p>}
+
+        {status === "idle" && (
+          <div role="alert" className="bg-orange-900/30 border border-orange-700 rounded-lg px-4 py-3 max-w-md w-full text-center text-orange-300 text-sm">
+            {error ?? "No pack available."}
+          </div>
+        )}
+
+        {pack && (status === "playing" || status === "revealing") && currentPlayer && (
+          <>
+            {pack.club.badge && (
+              <img src={pack.club.badge} alt={pack.club.name} className="w-16 h-16 object-contain" />
+            )}
+
+            <ProgressStrip total={pack.players.length} attempts={attempts} currentIndex={currentIndex} />
+
+            <div className="text-lg">
+              Player <span className="font-bold text-green-400">{currentIndex + 1}</span>
+              <span className="text-gray-500"> / {pack.players.length}</span>
+              <span className="text-gray-500 ml-4">Score: <span className="text-green-400 font-bold">{score}</span></span>
+            </div>
+
+            <div className="text-sm text-gray-400">
+              Guesses: <span className={`font-bold ${guessesForCurrent >= MAX_GUESSES_PER_PLAYER - 1 ? "text-red-400" : "text-green-400"}`}>{guessesForCurrent}</span>
+              <span className="text-gray-500"> / {MAX_GUESSES_PER_PLAYER}</span>
+            </div>
+
+            <div className="bg-gray-800 border border-gray-600 rounded-xl p-4 max-w-sm w-full">
+              <img
+                src={currentPlayer.thumbnail}
+                alt={status === "revealing" ? currentPlayer.name : "Mystery player"}
+                className="w-full aspect-square object-cover rounded-lg bg-gray-700"
+              />
+              {status === "revealing" && (
+                <div className="mt-3 text-center">
+                  <p className={`text-xl font-bold ${lastAttempt?.correct ? "text-green-400" : "text-red-400"}`}>
+                    {currentPlayer.name}
+                  </p>
+                  <p className="text-gray-400 text-sm">{lastAttempt?.correct ? "Correct!" : "Out of guesses"}</p>
+                </div>
+              )}
+            </div>
+
+            {status === "playing" && (
+              <PlayerSearch onSelect={submitGuess} placeholder="Player name" hideThumbnails />
+            )}
+
+            {wrongGuessesForCurrent.length > 0 && (
+              <div className="text-sm text-gray-400">
+                Wrong: {wrongGuessesForCurrent.map((p) => p.name).join(", ")}
+              </div>
+            )}
+          </>
+        )}
+
+        {status === "finished" && pack && (
+          <>
+            <h2 className="text-3xl font-bold text-green-400">Pack complete!</h2>
+            <p className="text-2xl">
+              <span className="font-bold text-green-400">{score}</span>
+              <span className="text-gray-400"> / {pack.players.length}</span>
+            </p>
+            <ProgressStrip total={pack.players.length} attempts={attempts} currentIndex={currentIndex} />
+            <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
+              Back to Home
+            </Link>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function ProgressStrip({
+  total,
+  attempts,
+  currentIndex,
+}: {
+  total: number;
+  attempts: { correct: boolean }[];
+  currentIndex: number;
+}) {
+  return (
+    <div role="list" aria-label="Pack progress" className="flex gap-1.5">
+      {Array.from({ length: total }, (_, i) => {
+        const a = attempts[i];
+        const cls =
+          a?.correct ? "bg-green-500" :
+          a && !a.correct ? "bg-red-500" :
+          i === currentIndex ? "bg-yellow-500" :
+          "bg-gray-700";
+        return <span key={i} role="listitem" className={`w-3 h-3 rounded-full ${cls}`} />;
+      })}
+    </div>
+  );
+}

--- a/src/pages/Pack/types.ts
+++ b/src/pages/Pack/types.ts
@@ -1,0 +1,32 @@
+import type { Player, PlayerWithTeams } from "../../types";
+
+export type PackStatus = "loading" | "idle" | "playing" | "revealing" | "finished";
+
+export interface PackClub {
+  id: string;
+  name: string;
+  badge: string;
+}
+
+export interface PackData {
+  date: string;
+  club: PackClub;
+  players: PlayerWithTeams[];
+}
+
+export interface PackAttempt {
+  playerId: string;
+  correct: boolean;
+  guesses: number;
+}
+
+export interface PackGameState {
+  pack: PackData | null;
+  currentIndex: number;
+  guessesForCurrent: number;
+  wrongGuessesForCurrent: Player[];
+  status: PackStatus;
+  attempts: PackAttempt[];
+  score: number;
+  error: string | null;
+}

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+import { getPackForDate } from "../../api/packSchedule";
+import type { Player } from "../../types";
+import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
+import type { PackGameState } from "./types";
+import { getTodayString } from "../../utils/dates";
+
+const REVEAL_MS = 1500;
+
+const EMPTY: PackGameState = {
+  pack: null,
+  currentIndex: 0,
+  guessesForCurrent: 0,
+  wrongGuessesForCurrent: [],
+  status: "loading",
+  attempts: [],
+  score: 0,
+  error: null,
+};
+
+export function usePackGame() {
+  const [today] = useState(getTodayString);
+  const [state, setState] = useState<PackGameState>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const pack = await getPackForDate(today);
+        if (cancelled) return;
+        if (!pack) {
+          setState({ ...EMPTY, status: "idle", error: "No pack scheduled for today." });
+          return;
+        }
+        setState(initialState(pack));
+      } catch (e) {
+        if (cancelled) return;
+        const message = e instanceof Error ? e.message : "Something went wrong";
+        setState({ ...EMPTY, status: "idle", error: message });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [today]);
+
+  const submitGuess = useCallback((guess: Player) => {
+    setState((s) => reduceGuess(s, guess));
+  }, []);
+
+  const advance = useCallback(() => {
+    setState((s) => reduceAdvance(s));
+  }, []);
+
+  useEffect(() => {
+    if (state.status !== "revealing") return;
+    const id = setTimeout(() => {
+      setState((s) => (s.status === "revealing" ? reduceAdvance(s) : s));
+    }, REVEAL_MS);
+    return () => clearTimeout(id);
+  }, [state.status, state.currentIndex]);
+
+  return { state, submitGuess, advance, today };
+}

--- a/supabase/migrations/012_pack_mode.sql
+++ b/supabase/migrations/012_pack_mode.sql
@@ -1,0 +1,62 @@
+-- Pack mode: 10 players from one club per day
+-- Mirrors daily_schedule (admin-curated) and daily_results (anon-insert) RLS shape
+
+CREATE TABLE pack_schedule (
+  date TEXT PRIMARY KEY,
+  club_id TEXT NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+  player_ids TEXT[] NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT pack_schedule_ten_players CHECK (array_length(player_ids, 1) = 10)
+);
+
+ALTER TABLE pack_schedule ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read pack_schedule" ON pack_schedule FOR SELECT USING (true);
+CREATE POLICY "Admins can insert pack_schedule" ON pack_schedule FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admins can update pack_schedule" ON pack_schedule FOR UPDATE USING (is_admin());
+CREATE POLICY "Admins can delete pack_schedule" ON pack_schedule FOR DELETE USING (is_admin());
+
+CREATE TABLE pack_results (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  date TEXT NOT NULL,
+  score INT NOT NULL CHECK (score >= 0 AND score <= 10),
+  attempts_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_pack_results_date ON pack_results(date);
+
+ALTER TABLE pack_results ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read pack_results" ON pack_results FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert pack_results" ON pack_results FOR INSERT WITH CHECK (true);
+
+-- Seed today's pack: pick any club that has at least 10 visible non-youth players,
+-- prefer top clubs. Skips silently if no qualifying club exists yet.
+DO $$
+DECLARE
+  picked_club_id TEXT;
+  picked_player_ids TEXT[];
+BEGIN
+  SELECT pc.club_id, ARRAY(
+    SELECT pc2.player_id
+    FROM player_clubs pc2
+    WHERE pc2.club_id = pc.club_id
+      AND COALESCE(pc2.is_hidden, false) = false
+      AND COALESCE(pc2.is_youth_team, false) = false
+    LIMIT 10
+  )
+  INTO picked_club_id, picked_player_ids
+  FROM player_clubs pc
+  JOIN clubs c ON c.id = pc.club_id
+  WHERE COALESCE(pc.is_hidden, false) = false
+    AND COALESCE(pc.is_youth_team, false) = false
+  GROUP BY pc.club_id, c.is_top_club
+  HAVING COUNT(DISTINCT pc.player_id) >= 10
+  ORDER BY c.is_top_club DESC NULLS LAST, RANDOM()
+  LIMIT 1;
+
+  IF picked_club_id IS NOT NULL AND array_length(picked_player_ids, 1) = 10 THEN
+    INSERT INTO pack_schedule (date, club_id, player_ids)
+    VALUES (CURRENT_DATE::TEXT, picked_club_id, picked_player_ids)
+    ON CONFLICT (date) DO NOTHING;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- New `/pack` route with the minimal one-at-a-time photo-guess loop: 10 players from one club, 3 guesses each, raw N/10 score
- Pure state machine in `src/pages/Pack/gameLogic.ts` with full unit coverage; integration covered by Playwright happy-path against real staging data
- Migration 012 adds `pack_schedule` (admin-curated, 10-player CHECK constraint) + `pack_results` (anon-insert), RLS mirrors `daily_schedule`/`daily_results`. Seeds today's pack from any club with >=10 visible non-youth players
- `PlayerSearch` gains an opt-in `hideThumbnails` prop so the autocomplete doesn't leak the answer in pack mode

This is the tracer per `.scratch/pack-mode/issues/01-pack-mode-tracer.md`. No hints, no scoring grid, no share text, no streak, no leaderboard yet — those are subsequent slices.

## Test plan
- [ ] `npm test` — 8 new unit tests on the state machine
- [ ] `npm run test:e2e -- e2e/pack-tracer.spec.ts` against staging where migration 012 is applied
- [ ] Manual: `/pack` renders today's seeded pack; correct guess advances; 3 wrong guesses reveals + advances; finishing all 10 shows N/10
- [ ] Visual: autocomplete no longer shows thumbnails on `/pack` (still shown on `/guess` and `/battle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)