### PR TITLE
feat: pack mode progressive hints (slice 02)

### DIFF
--- a/e2e/pack-hints.spec.ts
+++ b/e2e/pack-hints.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode hints", () => {
+  test("wrong guesses progressively reveal nationality then position", async ({ page }) => {
+    await page.goto("/#/pack");
+
+    const search = page.getByPlaceholder("Player name");
+    const ready = await search.waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const hintsList = page.getByLabel("Hints");
+
+    // No hints before any wrong guess.
+    await expect(hintsList).toHaveCount(0);
+
+    // Submit a wrong guess.
+    await search.fill("Wayne Rooney");
+    let option = page.getByRole("option").first();
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.click();
+
+    // If that was the answer we advance — skip rest.
+    if (await page.getByText(/Player\s+2\s*\/\s*10/).isVisible()) {
+      test.skip(true, "First guess matched the seeded player; can't exercise hint progression.");
+      return;
+    }
+
+    // 1 wrong → nationality only.
+    await expect(page.getByLabel("Hints").getByText("Nationality")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Position")).toHaveCount(0);
+
+    // 2nd wrong guess.
+    await search.fill("Lionel Messi");
+    option = page.getByRole("option").first();
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.click();
+
+    if (await page.getByText(/Player\s+2\s*\/\s*10/).isVisible()) {
+      test.skip(true, "Second guess matched.");
+      return;
+    }
+
+    await expect(page.getByLabel("Hints").getByText("Nationality")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Position")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Era at this club")).toHaveCount(0);
+  });
+});

--- a/src/__tests__/packHints.test.ts
+++ b/src/__tests__/packHints.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { deriveHints } from "../pages/Pack/hints";
+import type { PlayerWithTeams } from "../types";
+
+function makePlayer(overrides: Partial<PlayerWithTeams> = {}): PlayerWithTeams {
+  return {
+    id: "p1",
+    name: "Test Player",
+    thumbnail: "",
+    nationality: "Brazil",
+    position: "Midfielder",
+    formerTeams: [
+      { teamId: "pack-club", teamName: "Pack FC", yearJoined: "2018", yearDeparted: "2024", badge: "" },
+      { teamId: "other-1", teamName: "Other FC", yearJoined: "2014", yearDeparted: "2018", badge: "" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("deriveHints", () => {
+  it("reveals nothing when there have been no wrong guesses", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 0)).toEqual({});
+  });
+
+  it("reveals nationality after 1 wrong guess", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 1)).toEqual({ nationality: "Brazil" });
+  });
+
+  it("reveals position after 2 wrong, keeping nationality", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 2)).toEqual({
+      nationality: "Brazil",
+      position: "Midfielder",
+    });
+  });
+
+  it("reveals era at the pack club and one other career club after 3 wrong", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 3)).toEqual({
+      nationality: "Brazil",
+      position: "Midfielder",
+      era: "2018–2024",
+      otherClub: "Other FC",
+    });
+  });
+
+  it("omits otherClub gracefully when the player has only the pack club", () => {
+    const player = makePlayer({
+      formerTeams: [
+        { teamId: "pack-club", teamName: "Pack FC", yearJoined: "2018", yearDeparted: "2024", badge: "" },
+      ],
+    });
+    const hints = deriveHints(player, "pack-club", 3);
+    expect(hints.era).toBe("2018–2024");
+    expect(hints.otherClub).toBeUndefined();
+    expect("otherClub" in hints).toBe(false);
+  });
+
+  it("omits era when the player never appears at the pack club", () => {
+    const player = makePlayer({
+      formerTeams: [
+        { teamId: "other-1", teamName: "Other FC", yearJoined: "2014", yearDeparted: "2018", badge: "" },
+      ],
+    });
+    const hints = deriveHints(player, "pack-club", 3);
+    expect(hints.era).toBeUndefined();
+    expect(hints.otherClub).toBe("Other FC");
+  });
+});

--- a/src/pages/Pack/hints.ts
+++ b/src/pages/Pack/hints.ts
@@ -1,0 +1,35 @@
+import type { FormerTeam, PlayerWithTeams } from "../../types";
+
+export interface PackHints {
+  nationality?: string;
+  position?: string;
+  era?: string;
+  otherClub?: string;
+}
+
+export function deriveHints(
+  player: PlayerWithTeams,
+  packClubId: string,
+  wrongCount: number,
+): PackHints {
+  const hints: PackHints = {};
+  if (wrongCount >= 1 && player.nationality) hints.nationality = player.nationality;
+  if (wrongCount >= 2 && player.position) hints.position = player.position;
+  if (wrongCount >= 3) {
+    const era = formatEra(player.formerTeams.find((t) => t.teamId === packClubId));
+    if (era) hints.era = era;
+    const other = player.formerTeams.find((t) => t.teamId !== packClubId);
+    if (other) hints.otherClub = other.teamName;
+  }
+  return hints;
+}
+
+function formatEra(team: FormerTeam | undefined): string | undefined {
+  if (!team) return undefined;
+  const j = team.yearJoined?.trim();
+  const d = team.yearDeparted?.trim();
+  if (j && d) return `${j}–${d}`;
+  if (j) return `${j}–present`;
+  if (d) return `until ${d}`;
+  return undefined;
+}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -2,12 +2,16 @@ import { Link } from "react-router-dom";
 import { usePackGame } from "./usePackGame";
 import PlayerSearch from "../../components/PlayerSearch";
 import { MAX_GUESSES_PER_PLAYER } from "./constants";
+import { deriveHints } from "./hints";
 
 export default function Pack() {
   const { state, submitGuess } = usePackGame();
   const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
   const currentPlayer = pack?.players[currentIndex] ?? null;
   const lastAttempt = attempts[attempts.length - 1];
+  const hints = currentPlayer && pack
+    ? deriveHints(currentPlayer, pack.club.id, wrongGuessesForCurrent.length)
+    : null;
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col">
@@ -65,6 +69,8 @@ export default function Pack() {
               )}
             </div>
 
+            {hints && <HintsList hints={hints} />}
+
             {status === "playing" && (
               <PlayerSearch onSelect={submitGuess} placeholder="Player name" hideThumbnails />
             )}
@@ -92,6 +98,25 @@ export default function Pack() {
         )}
       </main>
     </div>
+  );
+}
+
+function HintsList({ hints }: { hints: ReturnType<typeof deriveHints> }) {
+  const items: { label: string; value: string }[] = [];
+  if (hints.nationality) items.push({ label: "Nationality", value: hints.nationality });
+  if (hints.position) items.push({ label: "Position", value: hints.position });
+  if (hints.era) items.push({ label: "Era at this club", value: hints.era });
+  if (hints.otherClub) items.push({ label: "Also played for", value: hints.otherClub });
+  if (items.length === 0) return null;
+  return (
+    <dl aria-label="Hints" className="grid grid-cols-2 gap-x-4 gap-y-1 max-w-sm w-full text-sm">
+      {items.map((item) => (
+        <div key={item.label} className="contents">
+          <dt className="text-gray-400 text-right">{item.label}</dt>
+          <dd className="text-white font-medium">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 


### PR DESCRIPTION
## Summary
- Pure `deriveHints(player, packClubId, wrongCount)` in `src/pages/Pack/hints.ts` returns the cumulative hint set
- Wrong 1 → nationality. Wrong 2 → + position. Wrong 3 → + era at pack club + one other career club
- Era is derived from the matching `player_clubs` row, not hardcoded
- Gracefully omits fields when source data is missing (player has no other club, or never appears at pack club)
- Hints render under the photo as a definition list and accumulate as wrong guesses pile up

Stacks on #50 (slice 01 / tracer). Per `.scratch/pack-mode/issues/02-progressive-hints.md`.

## Test plan
- [ ] `npm test` — 6 new unit tests on `deriveHints` cover each reveal step + graceful omission
- [ ] `npm run test:e2e -- e2e/pack-hints.spec.ts` against staging — wrong-then-wrong reveals nationality then position
- [ ] Manual: play /pack, confirm hints appear in order (nationality → position → era + other club) and disappear after advancing to the next player

🤖 Generated with [Claude Code](https://claude.com/claude-code)