### PR TITLE
feat: pack mode score grid, share, per-day persistence (slice 03)

### DIFF
--- a/e2e/pack-share.spec.ts
+++ b/e2e/pack-share.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode score & share", () => {
+  test("revisiting after completion shows the finished screen with N/10, day number, and emoji grid", async ({ page }) => {
+    // First, load /pack to ensure migration is applied and a club name is available.
+    await page.goto("/#/pack");
+    const search = page.getByPlaceholder("Player name");
+    const ready = await search.waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    // Inject a finished-state localStorage entry for today, then revisit.
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 7,
+        guesses: i < 7 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 7, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+
+    // Finished screen appears in place of the play UI.
+    await expect(page.getByText(/Pack #\d+/)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("7/10")).toBeVisible();
+    await expect(page.getByLabel("Result grid")).toContainText("✅");
+    await expect(page.getByLabel("Result grid")).toContainText("❌");
+    await expect(page.getByRole("button", { name: /Share Result/ })).toBeVisible();
+
+    // Search input is no longer present.
+    await expect(page.getByPlaceholder("Player name")).toHaveCount(0);
+  });
+
+  test("share button copies a formatted share string to the clipboard", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto("/#/pack");
+    const ready = await page.getByPlaceholder("Player name").waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 7,
+        guesses: i < 7 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 7, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+    await page.getByRole("button", { name: /Share Result/ }).click();
+    await expect(page.getByRole("button", { name: /Copied!/ })).toBeVisible();
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    expect(text).toMatch(/Football Nerdle Pack #\d+/);
+    expect(text).toContain("7/10");
+    expect(text).toContain("✅✅✅✅✅✅✅❌❌❌");
+    expect(text).toContain("https://spiritsack.github.io/football-nerdle/#/pack");
+  });
+});

--- a/src/__tests__/packHelpers.test.ts
+++ b/src/__tests__/packHelpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getPackDayNumber,
+  getDateForPackDay,
+  buildShareText,
+  savePackResult,
+  loadPackResult,
+} from "../pages/Pack/helpers";
+import type { PackAttempt } from "../pages/Pack/types";
+
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  const shim = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  };
+  vi.stubGlobal("localStorage", shim);
+}
+
+describe("getPackDayNumber", () => {
+  it("returns 1 for the launch date", () => {
+    expect(getPackDayNumber("2026-05-04")).toBe(1);
+  });
+
+  it("returns 2 for the day after launch", () => {
+    expect(getPackDayNumber("2026-05-05")).toBe(2);
+  });
+
+  it("is independent of the Guess the Player day numbering", () => {
+    // Same date should not produce the GuessThePlayer day-number anchored to 2026-03-24
+    const packDay = getPackDayNumber("2026-05-04");
+    expect(packDay).toBe(1);
+  });
+});
+
+describe("getDateForPackDay", () => {
+  it("is the inverse of getPackDayNumber", () => {
+    for (let day = 1; day <= 30; day++) {
+      expect(getPackDayNumber(getDateForPackDay(day))).toBe(day);
+    }
+  });
+});
+
+function attempts(pattern: boolean[]): PackAttempt[] {
+  return pattern.map((correct, i) => ({ playerId: `p${i + 1}`, correct, guesses: correct ? 1 : 3 }));
+}
+
+describe("buildShareText", () => {
+  it("includes pack day number, club name, score, and emoji grid", () => {
+    const text = buildShareText({
+      date: "2026-05-04",
+      clubName: "Liverpool",
+      score: 7,
+      attempts: attempts([true, true, false, true, true, true, false, true, true, false]),
+    });
+    expect(text).toContain("Pack #1");
+    expect(text).toContain("Liverpool");
+    expect(text).toContain("7/10");
+    expect(text).toContain("✅✅❌✅✅✅❌✅✅❌");
+  });
+
+  it("includes the share URL", () => {
+    const text = buildShareText({
+      date: "2026-05-04",
+      clubName: "Liverpool",
+      score: 0,
+      attempts: attempts(Array(10).fill(false)),
+    });
+    expect(text).toContain("https://spiritsack.github.io/football-nerdle/#/pack");
+  });
+});
+
+describe("pack result localStorage", () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it("round-trips a saved result", () => {
+    const a = attempts([true, false, true, false, true, false, true, false, true, false]);
+    savePackResult({ date: "2026-05-04", score: 5, attempts: a });
+    expect(loadPackResult("2026-05-04")).toEqual({ date: "2026-05-04", score: 5, attempts: a });
+  });
+
+  it("returns null when nothing is saved for that date", () => {
+    expect(loadPackResult("2026-05-04")).toBeNull();
+  });
+
+  it("uses a date-scoped key separate from the daily-guess key", () => {
+    savePackResult({ date: "2026-05-04", score: 5, attempts: [] });
+    expect(localStorage.getItem("football-nerdle-pack-2026-05-04")).not.toBeNull();
+    expect(localStorage.getItem("football-nerdle-daily-2026-05-04")).toBeNull();
+  });
+});

--- a/src/pages/Pack/constants.ts
+++ b/src/pages/Pack/constants.ts
@@ -1,2 +1,5 @@
 export const PACK_SIZE = 10;
 export const MAX_GUESSES_PER_PLAYER = 3;
+export const PACK_DAY_ONE_DATE = "2026-05-04";
+export const PACK_RESULT_PREFIX = "football-nerdle-pack-";
+export const PACK_SHARE_URL = "https://spiritsack.github.io/football-nerdle/#/pack";

--- a/src/pages/Pack/helpers.ts
+++ b/src/pages/Pack/helpers.ts
@@ -1,0 +1,53 @@
+import { PACK_DAY_ONE_DATE, PACK_RESULT_PREFIX, PACK_SHARE_URL } from "./constants";
+import type { PackAttempt } from "./types";
+
+const MS_PER_DAY = 86_400_000;
+
+export function getPackDayNumber(date: string): number {
+  const start = new Date(`${PACK_DAY_ONE_DATE}T00:00:00Z`);
+  const current = new Date(`${date}T00:00:00Z`);
+  return Math.floor((current.getTime() - start.getTime()) / MS_PER_DAY) + 1;
+}
+
+export function getDateForPackDay(day: number): string {
+  const start = new Date(`${PACK_DAY_ONE_DATE}T00:00:00Z`);
+  start.setUTCDate(start.getUTCDate() + (day - 1));
+  return start.toISOString().slice(0, 10);
+}
+
+export interface SavedPackResult {
+  date: string;
+  score: number;
+  attempts: PackAttempt[];
+}
+
+export function savePackResult(result: SavedPackResult): void {
+  try {
+    localStorage.setItem(PACK_RESULT_PREFIX + result.date, JSON.stringify(result));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function loadPackResult(date: string): SavedPackResult | null {
+  try {
+    const raw = localStorage.getItem(PACK_RESULT_PREFIX + date);
+    if (!raw) return null;
+    return JSON.parse(raw) as SavedPackResult;
+  } catch {
+    return null;
+  }
+}
+
+export interface ShareInput {
+  date: string;
+  clubName: string;
+  score: number;
+  attempts: PackAttempt[];
+}
+
+export function buildShareText({ date, clubName, score, attempts }: ShareInput): string {
+  const dayNum = getPackDayNumber(date);
+  const grid = attempts.map((a) => (a.correct ? "✅" : "❌")).join("");
+  return `Football Nerdle Pack #${dayNum} — ${clubName} ${score}/10\n${grid}\n${PACK_SHARE_URL}`;
+}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { usePackGame } from "./usePackGame";
 import PlayerSearch from "../../components/PlayerSearch";
 import { MAX_GUESSES_PER_PLAYER } from "./constants";
 import { deriveHints } from "./hints";
+import { buildShareText, getPackDayNumber } from "./helpers";
 
 export default function Pack() {
   const { state, submitGuess } = usePackGame();
@@ -12,6 +14,21 @@ export default function Pack() {
   const hints = currentPlayer && pack
     ? deriveHints(currentPlayer, pack.club.id, wrongGuessesForCurrent.length)
     : null;
+  const [copied, setCopied] = useState(false);
+
+  function handleShare() {
+    if (!pack) return;
+    const text = buildShareText({
+      date: pack.date,
+      clubName: pack.club.name,
+      score,
+      attempts,
+    });
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col">
@@ -85,15 +102,26 @@ export default function Pack() {
 
         {status === "finished" && pack && (
           <>
-            <h2 className="text-3xl font-bold text-green-400">Pack complete!</h2>
-            <p className="text-2xl">
-              <span className="font-bold text-green-400">{score}</span>
-              <span className="text-gray-400"> / {pack.players.length}</span>
+            <p className="text-gray-300 text-lg">
+              {pack.club.name} · Pack #{getPackDayNumber(pack.date)}
             </p>
-            <ProgressStrip total={pack.players.length} attempts={attempts} currentIndex={currentIndex} />
-            <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
-              Back to Home
-            </Link>
+            <p className="text-7xl font-bold bg-gradient-to-br from-green-300 to-emerald-500 bg-clip-text text-transparent">
+              {score}<span className="text-gray-500">/{pack.players.length}</span>
+            </p>
+            <p className="text-2xl tracking-wide" aria-label="Result grid">
+              {attempts.map((a) => (a.correct ? "✅" : "❌")).join("")}
+            </p>
+            <div className="flex gap-3 flex-wrap justify-center">
+              <button
+                onClick={handleShare}
+                className="px-6 py-3 bg-blue-600 hover:bg-blue-500 rounded-lg font-semibold transition-colors"
+              >
+                {copied ? "Copied!" : "Share Result"}
+              </button>
+              <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
+                Back to Home
+              </Link>
+            </div>
           </>
         )}
       </main>

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -4,6 +4,7 @@ import type { Player } from "../../types";
 import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
 import type { PackGameState } from "./types";
 import { getTodayString } from "../../utils/dates";
+import { loadPackResult, savePackResult } from "./helpers";
 
 const REVEAL_MS = 1500;
 
@@ -32,6 +33,17 @@ export function usePackGame() {
           setState({ ...EMPTY, status: "idle", error: "No pack scheduled for today." });
           return;
         }
+        const stored = loadPackResult(today);
+        if (stored && stored.attempts.length === pack.players.length) {
+          setState({
+            ...initialState(pack),
+            status: "finished",
+            attempts: stored.attempts,
+            score: stored.score,
+            currentIndex: pack.players.length,
+          });
+          return;
+        }
         setState(initialState(pack));
       } catch (e) {
         if (cancelled) return;
@@ -41,6 +53,15 @@ export function usePackGame() {
     })();
     return () => { cancelled = true; };
   }, [today]);
+
+  useEffect(() => {
+    if (state.status !== "finished" || !state.pack) return;
+    savePackResult({
+      date: state.pack.date,
+      score: state.score,
+      attempts: state.attempts,
+    });
+  }, [state.status, state.pack, state.score, state.attempts]);
 
   const submitGuess = useCallback((guess: Player) => {
     setState((s) => reduceGuess(s, guess));


### PR DESCRIPTION
## Summary
- Final-score screen: gradient `N/10`, team name, pack-scoped day number (Pack #N anchored to 2026-05-04), single-line emoji grid (✅/❌)
- "Share Result" button copies a formatted share string to the clipboard
- Per-day result persists to `football-nerdle-pack-YYYY-MM-DD`; revisiting `/pack` on the same day surfaces the completed result instead of replaying
- Pack day numbering is independent from the existing Guess the Player day numbering

Stacks on #51 (slice 02 / hints). Per `.scratch/pack-mode/issues/03-score-share-grid.md`.

## Test plan
- [ ] `npm test` — 9 new unit tests on date math, share text, and localStorage round-trip
- [ ] `npm run test:e2e -- e2e/pack-share.spec.ts` — finished screen + clipboard copy
- [ ] Manual: complete a pack, see final screen; refresh — completed state remains; click Share — clipboard contains formatted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)