### PR TITLE
feat: pack mode stats + gap-aware streak (slice 04)

### DIFF
--- a/e2e/pack-stats.spec.ts
+++ b/e2e/pack-stats.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode stats panel", () => {
+  test("renders persisted stats on the finished screen", async ({ page }) => {
+    await page.goto("/#/pack");
+    const ready = await page.getByPlaceholder("Player name").waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      localStorage.setItem(
+        "football-nerdle-pack-stats",
+        JSON.stringify({
+          played: 5,
+          totalScore: 38,
+          bestScore: 9,
+          streak: 4,
+          longestStreak: 6,
+          lastPlayedDate: date,
+          lastSuccessDate: date,
+        }),
+      );
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 8,
+        guesses: i < 8 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 8, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+
+    const stats = page.getByLabel("Pack stats");
+    await expect(stats).toBeVisible({ timeout: 15_000 });
+    await expect(stats.getByText("Played")).toBeVisible();
+    await expect(stats.getByText("Streak")).toBeVisible();
+    await expect(stats.getByText("Longest")).toBeVisible();
+
+    // Persisted values are reflected.
+    await expect(stats).toContainText("5");  // played
+    await expect(stats).toContainText("9");  // best
+    await expect(stats).toContainText("4");  // streak
+    await expect(stats).toContainText("6");  // longest
+    await expect(stats).toContainText(/Avg:\s*7\.6\s*\/\s*10/);
+  });
+});

--- a/src/__tests__/packStats.test.ts
+++ b/src/__tests__/packStats.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { recordPackResult, loadPackStats, DEFAULT_PACK_STATS } from "../pages/Pack/stats";
+
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  });
+}
+
+const NEVER_MET = () => false;
+const ALWAYS_MET = () => true;
+
+describe("recordPackResult — first-ever play", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("score >= threshold yields streak 1, longestStreak 1, played 1, lastSuccessDate=today", () => {
+    const stats = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 7, [], NEVER_MET);
+    expect(stats.played).toBe(1);
+    expect(stats.totalScore).toBe(7);
+    expect(stats.bestScore).toBe(7);
+    expect(stats.streak).toBe(1);
+    expect(stats.longestStreak).toBe(1);
+    expect(stats.lastPlayedDate).toBe("2026-05-04");
+    expect(stats.lastSuccessDate).toBe("2026-05-04");
+  });
+
+  it("score below threshold yields streak 0 and no lastSuccessDate", () => {
+    const stats = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 6, [], NEVER_MET);
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(0);
+    expect(stats.lastSuccessDate).toBeUndefined();
+    expect(stats.lastPlayedDate).toBe("2026-05-04");
+  });
+});
+
+describe("recordPackResult — streak advance and break", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("advances on a passing score the day after the previous success (no gap)", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    const day2 = recordPackResult(day1, "2026-05-05", 9, [], NEVER_MET);
+    expect(day2.streak).toBe(2);
+    expect(day2.longestStreak).toBe(2);
+  });
+
+  it("survives a calendar gap on dates that had no pack scheduled", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // No pack on 2026-05-05; user plays again on 2026-05-06.
+    const day3 = recordPackResult(day1, "2026-05-06", 7, [], ALWAYS_MET);
+    expect(day3.streak).toBe(2);
+  });
+
+  it("breaks when a scheduled day between last success and today was missed", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // Pack scheduled on 2026-05-05 — user did not play it.
+    const day3 = recordPackResult(day1, "2026-05-06", 8, ["2026-05-05"], NEVER_MET);
+    expect(day3.streak).toBe(1);
+    expect(day3.longestStreak).toBe(1);
+  });
+
+  it("survives when scheduled in-between days were played at threshold but stats weren't updated for them", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // Pack scheduled on 2026-05-05 and the user did meet the threshold there
+    // (according to the per-day result store), even though stats weren't recorded.
+    const day3 = recordPackResult(day1, "2026-05-06", 8, ["2026-05-05"], (d) => d === "2026-05-05");
+    expect(day3.streak).toBe(2);
+  });
+
+  it("a sub-threshold score breaks the streak even when prior days were perfect", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 10, [], NEVER_MET);
+    const day2 = recordPackResult(day1, "2026-05-05", 5, [], NEVER_MET);
+    expect(day2.streak).toBe(0);
+    expect(day2.longestStreak).toBe(1);
+  });
+});
+
+describe("loadPackStats", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("returns defaults when nothing is stored", () => {
+    expect(loadPackStats()).toEqual(DEFAULT_PACK_STATS);
+  });
+
+  it("round-trips through recordPackResult", () => {
+    recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 9, [], NEVER_MET);
+    const reloaded = loadPackStats();
+    expect(reloaded.played).toBe(1);
+    expect(reloaded.bestScore).toBe(9);
+    expect(reloaded.streak).toBe(1);
+  });
+});

--- a/src/api/packSchedule.ts
+++ b/src/api/packSchedule.ts
@@ -32,3 +32,21 @@ export async function getPackForDate(date: string): Promise<PackData | null> {
     players: valid,
   };
 }
+
+export async function getScheduledPackDatesBetween(
+  exclusiveStart: string,
+  exclusiveEnd: string,
+): Promise<string[]> {
+  if (!supabase) return [];
+  if (exclusiveStart >= exclusiveEnd) return [];
+  try {
+    const { data } = await supabase
+      .from("pack_schedule")
+      .select("date")
+      .gt("date", exclusiveStart)
+      .lt("date", exclusiveEnd);
+    return (data ?? []).map((r: { date: string }) => r.date);
+  } catch {
+    return [];
+  }
+}

--- a/src/pages/Pack/constants.ts
+++ b/src/pages/Pack/constants.ts
@@ -3,3 +3,5 @@ export const MAX_GUESSES_PER_PLAYER = 3;
 export const PACK_DAY_ONE_DATE = "2026-05-04";
 export const PACK_RESULT_PREFIX = "football-nerdle-pack-";
 export const PACK_SHARE_URL = "https://spiritsack.github.io/football-nerdle/#/pack";
+export const PACK_STATS_KEY = "football-nerdle-pack-stats";
+export const PACK_STREAK_THRESHOLD = 7;

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -7,7 +7,7 @@ import { deriveHints } from "./hints";
 import { buildShareText, getPackDayNumber } from "./helpers";
 
 export default function Pack() {
-  const { state, submitGuess } = usePackGame();
+  const { state, submitGuess, stats } = usePackGame();
   const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
   const currentPlayer = pack?.players[currentIndex] ?? null;
   const lastAttempt = attempts[attempts.length - 1];
@@ -121,6 +121,33 @@ export default function Pack() {
               <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
                 Back to Home
               </Link>
+            </div>
+
+            <div aria-label="Pack stats" className="bg-gray-800 border border-gray-600 rounded-xl p-6 max-w-md w-full">
+              <h3 className="text-lg font-semibold text-center text-gray-300 mb-4">Your Stats</h3>
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <div>
+                  <div className="text-2xl font-bold">{stats.played}</div>
+                  <div className="text-gray-400 text-xs">Played</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-green-400">{stats.bestScore}</div>
+                  <div className="text-gray-400 text-xs">Best</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-yellow-400">{stats.streak}</div>
+                  <div className="text-gray-400 text-xs">Streak</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-yellow-400">{stats.longestStreak}</div>
+                  <div className="text-gray-400 text-xs">Longest</div>
+                </div>
+              </div>
+              {stats.played > 0 && (
+                <div className="mt-3 text-center text-gray-400 text-sm">
+                  Avg: {(stats.totalScore / stats.played).toFixed(1)} / 10
+                </div>
+              )}
             </div>
           </>
         )}

--- a/src/pages/Pack/stats.ts
+++ b/src/pages/Pack/stats.ts
@@ -1,0 +1,63 @@
+import { PACK_STATS_KEY, PACK_STREAK_THRESHOLD } from "./constants";
+
+export interface PackStats {
+  played: number;
+  totalScore: number;
+  bestScore: number;
+  streak: number;
+  longestStreak: number;
+  lastPlayedDate?: string;
+  lastSuccessDate?: string;
+}
+
+export const DEFAULT_PACK_STATS: PackStats = {
+  played: 0,
+  totalScore: 0,
+  bestScore: 0,
+  streak: 0,
+  longestStreak: 0,
+};
+
+export function loadPackStats(): PackStats {
+  try {
+    const raw = localStorage.getItem(PACK_STATS_KEY);
+    if (!raw) return { ...DEFAULT_PACK_STATS };
+    return { ...DEFAULT_PACK_STATS, ...(JSON.parse(raw) as Partial<PackStats>) };
+  } catch {
+    return { ...DEFAULT_PACK_STATS };
+  }
+}
+
+function savePackStats(stats: PackStats): void {
+  try {
+    localStorage.setItem(PACK_STATS_KEY, JSON.stringify(stats));
+  } catch {
+    // ignore
+  }
+}
+
+export function recordPackResult(
+  prev: PackStats,
+  date: string,
+  score: number,
+  scheduledBetween: string[],
+  metThresholdAt: (date: string) => boolean,
+): PackStats {
+  const passed = score >= PACK_STREAK_THRESHOLD;
+  let nextStreak = 0;
+  if (passed) {
+    const noBrokenScheduledGap = scheduledBetween.every((d) => metThresholdAt(d));
+    nextStreak = noBrokenScheduledGap ? prev.streak + 1 : 1;
+  }
+  const next: PackStats = {
+    played: prev.played + 1,
+    totalScore: prev.totalScore + score,
+    bestScore: Math.max(prev.bestScore, score),
+    streak: nextStreak,
+    longestStreak: Math.max(prev.longestStreak, nextStreak),
+    lastPlayedDate: date,
+    lastSuccessDate: passed ? date : prev.lastSuccessDate,
+  };
+  savePackStats(next);
+  return next;
+}

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
-import { getPackForDate } from "../../api/packSchedule";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getPackForDate, getScheduledPackDatesBetween } from "../../api/packSchedule";
 import type { Player } from "../../types";
 import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
 import type { PackGameState } from "./types";
 import { getTodayString } from "../../utils/dates";
 import { loadPackResult, savePackResult } from "./helpers";
+import { DEFAULT_PACK_STATS, loadPackStats, recordPackResult } from "./stats";
+import { PACK_STREAK_THRESHOLD } from "./constants";
+import type { PackStats } from "./stats";
 
 const REVEAL_MS = 1500;
 
@@ -22,6 +25,8 @@ const EMPTY: PackGameState = {
 export function usePackGame() {
   const [today] = useState(getTodayString);
   const [state, setState] = useState<PackGameState>(EMPTY);
+  const [stats, setStats] = useState<PackStats>(DEFAULT_PACK_STATS);
+  const recordedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -33,8 +38,10 @@ export function usePackGame() {
           setState({ ...EMPTY, status: "idle", error: "No pack scheduled for today." });
           return;
         }
+        setStats(loadPackStats());
         const stored = loadPackResult(today);
         if (stored && stored.attempts.length === pack.players.length) {
+          recordedRef.current = true;
           setState({
             ...initialState(pack),
             status: "finished",
@@ -61,6 +68,23 @@ export function usePackGame() {
       score: state.score,
       attempts: state.attempts,
     });
+
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    const date = state.pack.date;
+    const score = state.score;
+    const prior = loadPackStats();
+
+    (async () => {
+      const between = prior.lastSuccessDate
+        ? await getScheduledPackDatesBetween(prior.lastSuccessDate, date)
+        : [];
+      const updated = recordPackResult(prior, date, score, between, (d) => {
+        const r = loadPackResult(d);
+        return !!r && r.score >= PACK_STREAK_THRESHOLD;
+      });
+      setStats(updated);
+    })();
   }, [state.status, state.pack, state.score, state.attempts]);
 
   const submitGuess = useCallback((guess: Player) => {
@@ -79,5 +103,5 @@ export function usePackGame() {
     return () => clearTimeout(id);
   }, [state.status, state.currentIndex]);
 
-  return { state, submitGuess, advance, today };
+  return { state, submitGuess, advance, today, stats };
 }


### PR DESCRIPTION
## Summary
- Stats persisted under \`football-nerdle-pack-stats\`: played, totalScore, bestScore, streak, longestStreak, lastPlayedDate, lastSuccessDate
- Streak advances on score >= 7/10 and **survives calendar gaps** where no pack was scheduled
- Streak **breaks** on dates where a pack existed but the user did not play or did not meet threshold
- Pure \`recordPackResult\` takes the scheduled-between set and a per-date threshold predicate, so the rules can be exercised without UI
- New \`getScheduledPackDatesBetween(start, end)\` API queries the \`pack_schedule\` table
- Stats panel renders on the final-score screen with played / best / streak / longest / avg

Stacks on #52 (slice 03 / score grid). Per \`.scratch/pack-mode/issues/04-stats-streak.md\`.

## Test plan
- [ ] \`npm test\` — 9 new unit tests covering: first play (pass and fail), streak advance, gap survival on unscheduled days, gap break on a missed scheduled day, gap survival when an in-between scheduled day was passed, sub-threshold breaks streak, loadPackStats round-trip
- [ ] \`npm run test:e2e -- e2e/pack-stats.spec.ts\` — stats panel renders persisted values
- [ ] Manual: play a pack with score >= 7, see streak advance; lower score, streak resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)