### PR TITLE
feat: pack mode slices 02–06 (hints, score, stats, fallback)

### DIFF
--- a/e2e/pack-hints.spec.ts
+++ b/e2e/pack-hints.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode hints", () => {
+  test("wrong guesses progressively reveal nationality then position", async ({ page }) => {
+    await page.goto("/#/pack");
+
+    const search = page.getByPlaceholder("Player name");
+    const ready = await search.waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const hintsList = page.getByLabel("Hints");
+
+    // No hints before any wrong guess.
+    await expect(hintsList).toHaveCount(0);
+
+    // Submit a wrong guess.
+    await search.fill("Wayne Rooney");
+    let option = page.getByRole("option").first();
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.click();
+
+    // If that was the answer we advance — skip rest.
+    if (await page.getByText(/Player\s+2\s*\/\s*10/).isVisible()) {
+      test.skip(true, "First guess matched the seeded player; can't exercise hint progression.");
+      return;
+    }
+
+    // 1 wrong → nationality only.
+    await expect(page.getByLabel("Hints").getByText("Nationality")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Position")).toHaveCount(0);
+
+    // 2nd wrong guess.
+    await search.fill("Lionel Messi");
+    option = page.getByRole("option").first();
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.click();
+
+    if (await page.getByText(/Player\s+2\s*\/\s*10/).isVisible()) {
+      test.skip(true, "Second guess matched.");
+      return;
+    }
+
+    await expect(page.getByLabel("Hints").getByText("Nationality")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Position")).toBeVisible();
+    await expect(page.getByLabel("Hints").getByText("Era at this club")).toHaveCount(0);
+  });
+});

--- a/e2e/pack-no-pack-fallback.spec.ts
+++ b/e2e/pack-no-pack-fallback.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode — no pack today fallback", () => {
+  test.beforeEach(async ({ page }) => {
+    // Force the pack_schedule query to return empty regardless of seed state.
+    await page.route(/\/rest\/v1\/pack_schedule\?.*/, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+  });
+
+  test("renders friendly fallback with links to other modes", async ({ page }) => {
+    await page.goto("/#/pack");
+
+    const fallback = page.getByLabel("No pack today");
+    await expect(fallback).toBeVisible({ timeout: 15_000 });
+    await expect(fallback.getByText(/no pack today/i)).toBeVisible();
+
+    // Links to other modes are present.
+    await expect(fallback.getByRole("link", { name: "Guess the Player" })).toBeVisible();
+    await expect(fallback.getByRole("link", { name: "Battle Mode" })).toBeVisible();
+    await expect(fallback.getByRole("link", { name: "Home" })).toBeVisible();
+
+    // The play UI is NOT shown.
+    await expect(page.getByPlaceholder("Player name")).toHaveCount(0);
+    await expect(page.getByLabel("Pack progress")).toHaveCount(0);
+  });
+
+  test("does not modify pack stats", async ({ page }) => {
+    const seeded = {
+      played: 5,
+      totalScore: 38,
+      bestScore: 9,
+      streak: 4,
+      longestStreak: 6,
+      lastPlayedDate: "2026-04-30",
+      lastSuccessDate: "2026-04-30",
+    };
+
+    await page.goto("/#/pack");
+    await page.evaluate((s) => {
+      localStorage.setItem("football-nerdle-pack-stats", JSON.stringify(s));
+    }, seeded);
+
+    await page.goto("/#/pack");
+    await expect(page.getByLabel("No pack today")).toBeVisible({ timeout: 15_000 });
+
+    const after = await page.evaluate(() =>
+      JSON.parse(localStorage.getItem("football-nerdle-pack-stats") ?? "null"),
+    );
+    expect(after).toEqual(seeded);
+  });
+});

--- a/e2e/pack-share.spec.ts
+++ b/e2e/pack-share.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode score & share", () => {
+  test("revisiting after completion shows the finished screen with N/10, day number, and emoji grid", async ({ page }) => {
+    // First, load /pack to ensure migration is applied and a club name is available.
+    await page.goto("/#/pack");
+    const search = page.getByPlaceholder("Player name");
+    const ready = await search.waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    // Inject a finished-state localStorage entry for today, then revisit.
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 7,
+        guesses: i < 7 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 7, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+
+    // Finished screen appears in place of the play UI.
+    await expect(page.getByText(/Pack #\d+/)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("7/10")).toBeVisible();
+    await expect(page.getByLabel("Result grid")).toContainText("✅");
+    await expect(page.getByLabel("Result grid")).toContainText("❌");
+    await expect(page.getByRole("button", { name: /Share Result/ })).toBeVisible();
+
+    // Search input is no longer present.
+    await expect(page.getByPlaceholder("Player name")).toHaveCount(0);
+  });
+
+  test("share button copies a formatted share string to the clipboard", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto("/#/pack");
+    const ready = await page.getByPlaceholder("Player name").waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 7,
+        guesses: i < 7 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 7, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+    await page.getByRole("button", { name: /Share Result/ }).click();
+    await expect(page.getByRole("button", { name: /Copied!/ })).toBeVisible();
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    expect(text).toMatch(/Football Nerdle Pack #\d+/);
+    expect(text).toContain("7/10");
+    expect(text).toContain("✅✅✅✅✅✅✅❌❌❌");
+    expect(text).toContain("https://spiritsack.github.io/football-nerdle/#/pack");
+  });
+});

--- a/e2e/pack-stats.spec.ts
+++ b/e2e/pack-stats.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode stats panel", () => {
+  test("renders persisted stats on the finished screen", async ({ page }) => {
+    await page.goto("/#/pack");
+    const ready = await page.getByPlaceholder("Player name").waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    await page.evaluate((date) => {
+      localStorage.setItem(
+        "football-nerdle-pack-stats",
+        JSON.stringify({
+          played: 5,
+          totalScore: 38,
+          bestScore: 9,
+          streak: 4,
+          longestStreak: 6,
+          lastPlayedDate: date,
+          lastSuccessDate: date,
+        }),
+      );
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 8,
+        guesses: i < 8 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 8, attempts }),
+      );
+    }, today);
+
+    await page.goto("/#/pack");
+
+    const stats = page.getByLabel("Pack stats");
+    await expect(stats).toBeVisible({ timeout: 15_000 });
+    await expect(stats.getByText("Played")).toBeVisible();
+    await expect(stats.getByText("Streak")).toBeVisible();
+    await expect(stats.getByText("Longest")).toBeVisible();
+
+    // Persisted values are reflected.
+    await expect(stats).toContainText("5");  // played
+    await expect(stats).toContainText("9");  // best
+    await expect(stats).toContainText("4");  // streak
+    await expect(stats).toContainText("6");  // longest
+    await expect(stats).toContainText(/Avg:\s*7\.6\s*\/\s*10/);
+  });
+});

--- a/e2e/pack-tracer.spec.ts
+++ b/e2e/pack-tracer.spec.ts
@@ -5,11 +5,11 @@ test.describe("Pack Mode (tracer)", () => {
     await page.goto("/#/pack");
 
     const search = page.getByPlaceholder("Player name");
-    const idleAlert = page.getByRole("alert");
+    const fallback = page.getByLabel("No pack today");
 
     const outcome = await Promise.race([
       search.waitFor({ state: "visible", timeout: 15_000 }).then(() => "playing" as const).catch(() => null),
-      idleAlert.waitFor({ state: "visible", timeout: 15_000 }).then(() => "idle" as const).catch(() => null),
+      fallback.waitFor({ state: "visible", timeout: 15_000 }).then(() => "idle" as const).catch(() => null),
     ]);
 
     if (outcome === "idle") {

--- a/src/__tests__/packHelpers.test.ts
+++ b/src/__tests__/packHelpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getPackDayNumber,
+  getDateForPackDay,
+  buildShareText,
+  savePackResult,
+  loadPackResult,
+} from "../pages/Pack/helpers";
+import type { PackAttempt } from "../pages/Pack/types";
+
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  const shim = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  };
+  vi.stubGlobal("localStorage", shim);
+}
+
+describe("getPackDayNumber", () => {
+  it("returns 1 for the launch date", () => {
+    expect(getPackDayNumber("2026-05-04")).toBe(1);
+  });
+
+  it("returns 2 for the day after launch", () => {
+    expect(getPackDayNumber("2026-05-05")).toBe(2);
+  });
+
+  it("is independent of the Guess the Player day numbering", () => {
+    // Same date should not produce the GuessThePlayer day-number anchored to 2026-03-24
+    const packDay = getPackDayNumber("2026-05-04");
+    expect(packDay).toBe(1);
+  });
+});
+
+describe("getDateForPackDay", () => {
+  it("is the inverse of getPackDayNumber", () => {
+    for (let day = 1; day <= 30; day++) {
+      expect(getPackDayNumber(getDateForPackDay(day))).toBe(day);
+    }
+  });
+});
+
+function attempts(pattern: boolean[]): PackAttempt[] {
+  return pattern.map((correct, i) => ({ playerId: `p${i + 1}`, correct, guesses: correct ? 1 : 3 }));
+}
+
+describe("buildShareText", () => {
+  it("includes pack day number, club name, score, and emoji grid", () => {
+    const text = buildShareText({
+      date: "2026-05-04",
+      clubName: "Liverpool",
+      score: 7,
+      attempts: attempts([true, true, false, true, true, true, false, true, true, false]),
+    });
+    expect(text).toContain("Pack #1");
+    expect(text).toContain("Liverpool");
+    expect(text).toContain("7/10");
+    expect(text).toContain("✅✅❌✅✅✅❌✅✅❌");
+  });
+
+  it("includes the share URL", () => {
+    const text = buildShareText({
+      date: "2026-05-04",
+      clubName: "Liverpool",
+      score: 0,
+      attempts: attempts(Array(10).fill(false)),
+    });
+    expect(text).toContain("https://spiritsack.github.io/football-nerdle/#/pack");
+  });
+});
+
+describe("pack result localStorage", () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it("round-trips a saved result", () => {
+    const a = attempts([true, false, true, false, true, false, true, false, true, false]);
+    savePackResult({ date: "2026-05-04", score: 5, attempts: a });
+    expect(loadPackResult("2026-05-04")).toEqual({ date: "2026-05-04", score: 5, attempts: a });
+  });
+
+  it("returns null when nothing is saved for that date", () => {
+    expect(loadPackResult("2026-05-04")).toBeNull();
+  });
+
+  it("uses a date-scoped key separate from the daily-guess key", () => {
+    savePackResult({ date: "2026-05-04", score: 5, attempts: [] });
+    expect(localStorage.getItem("football-nerdle-pack-2026-05-04")).not.toBeNull();
+    expect(localStorage.getItem("football-nerdle-daily-2026-05-04")).toBeNull();
+  });
+});

--- a/src/__tests__/packHints.test.ts
+++ b/src/__tests__/packHints.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { deriveHints } from "../pages/Pack/hints";
+import type { PlayerWithTeams } from "../types";
+
+function makePlayer(overrides: Partial<PlayerWithTeams> = {}): PlayerWithTeams {
+  return {
+    id: "p1",
+    name: "Test Player",
+    thumbnail: "",
+    nationality: "Brazil",
+    position: "Midfielder",
+    formerTeams: [
+      { teamId: "pack-club", teamName: "Pack FC", yearJoined: "2018", yearDeparted: "2024", badge: "" },
+      { teamId: "other-1", teamName: "Other FC", yearJoined: "2014", yearDeparted: "2018", badge: "" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("deriveHints", () => {
+  it("reveals nothing when there have been no wrong guesses", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 0)).toEqual({});
+  });
+
+  it("reveals nationality after 1 wrong guess", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 1)).toEqual({ nationality: "Brazil" });
+  });
+
+  it("reveals position after 2 wrong, keeping nationality", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 2)).toEqual({
+      nationality: "Brazil",
+      position: "Midfielder",
+    });
+  });
+
+  it("reveals era at the pack club and one other career club after 3 wrong", () => {
+    expect(deriveHints(makePlayer(), "pack-club", 3)).toEqual({
+      nationality: "Brazil",
+      position: "Midfielder",
+      era: "2018–2024",
+      otherClub: "Other FC",
+    });
+  });
+
+  it("omits otherClub gracefully when the player has only the pack club", () => {
+    const player = makePlayer({
+      formerTeams: [
+        { teamId: "pack-club", teamName: "Pack FC", yearJoined: "2018", yearDeparted: "2024", badge: "" },
+      ],
+    });
+    const hints = deriveHints(player, "pack-club", 3);
+    expect(hints.era).toBe("2018–2024");
+    expect(hints.otherClub).toBeUndefined();
+    expect("otherClub" in hints).toBe(false);
+  });
+
+  it("omits era when the player never appears at the pack club", () => {
+    const player = makePlayer({
+      formerTeams: [
+        { teamId: "other-1", teamName: "Other FC", yearJoined: "2014", yearDeparted: "2018", badge: "" },
+      ],
+    });
+    const hints = deriveHints(player, "pack-club", 3);
+    expect(hints.era).toBeUndefined();
+    expect(hints.otherClub).toBe("Other FC");
+  });
+});

--- a/src/__tests__/packStats.test.ts
+++ b/src/__tests__/packStats.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { recordPackResult, loadPackStats, DEFAULT_PACK_STATS } from "../pages/Pack/stats";
+
+function installLocalStorageShim() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  });
+}
+
+const NEVER_MET = () => false;
+const ALWAYS_MET = () => true;
+
+describe("recordPackResult — first-ever play", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("score >= threshold yields streak 1, longestStreak 1, played 1, lastSuccessDate=today", () => {
+    const stats = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 7, [], NEVER_MET);
+    expect(stats.played).toBe(1);
+    expect(stats.totalScore).toBe(7);
+    expect(stats.bestScore).toBe(7);
+    expect(stats.streak).toBe(1);
+    expect(stats.longestStreak).toBe(1);
+    expect(stats.lastPlayedDate).toBe("2026-05-04");
+    expect(stats.lastSuccessDate).toBe("2026-05-04");
+  });
+
+  it("score below threshold yields streak 0 and no lastSuccessDate", () => {
+    const stats = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 6, [], NEVER_MET);
+    expect(stats.streak).toBe(0);
+    expect(stats.longestStreak).toBe(0);
+    expect(stats.lastSuccessDate).toBeUndefined();
+    expect(stats.lastPlayedDate).toBe("2026-05-04");
+  });
+});
+
+describe("recordPackResult — streak advance and break", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("advances on a passing score the day after the previous success (no gap)", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    const day2 = recordPackResult(day1, "2026-05-05", 9, [], NEVER_MET);
+    expect(day2.streak).toBe(2);
+    expect(day2.longestStreak).toBe(2);
+  });
+
+  it("survives a calendar gap on dates that had no pack scheduled", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // No pack on 2026-05-05; user plays again on 2026-05-06.
+    const day3 = recordPackResult(day1, "2026-05-06", 7, [], ALWAYS_MET);
+    expect(day3.streak).toBe(2);
+  });
+
+  it("breaks when a scheduled day between last success and today was missed", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // Pack scheduled on 2026-05-05 — user did not play it.
+    const day3 = recordPackResult(day1, "2026-05-06", 8, ["2026-05-05"], NEVER_MET);
+    expect(day3.streak).toBe(1);
+    expect(day3.longestStreak).toBe(1);
+  });
+
+  it("survives when scheduled in-between days were played at threshold but stats weren't updated for them", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 8, [], NEVER_MET);
+    // Pack scheduled on 2026-05-05 and the user did meet the threshold there
+    // (according to the per-day result store), even though stats weren't recorded.
+    const day3 = recordPackResult(day1, "2026-05-06", 8, ["2026-05-05"], (d) => d === "2026-05-05");
+    expect(day3.streak).toBe(2);
+  });
+
+  it("a sub-threshold score breaks the streak even when prior days were perfect", () => {
+    const day1 = recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 10, [], NEVER_MET);
+    const day2 = recordPackResult(day1, "2026-05-05", 5, [], NEVER_MET);
+    expect(day2.streak).toBe(0);
+    expect(day2.longestStreak).toBe(1);
+  });
+});
+
+describe("loadPackStats", () => {
+  beforeEach(installLocalStorageShim);
+
+  it("returns defaults when nothing is stored", () => {
+    expect(loadPackStats()).toEqual(DEFAULT_PACK_STATS);
+  });
+
+  it("round-trips through recordPackResult", () => {
+    recordPackResult(DEFAULT_PACK_STATS, "2026-05-04", 9, [], NEVER_MET);
+    const reloaded = loadPackStats();
+    expect(reloaded.played).toBe(1);
+    expect(reloaded.bestScore).toBe(9);
+    expect(reloaded.streak).toBe(1);
+  });
+});

--- a/src/api/packSchedule.ts
+++ b/src/api/packSchedule.ts
@@ -32,3 +32,21 @@ export async function getPackForDate(date: string): Promise<PackData | null> {
     players: valid,
   };
 }
+
+export async function getScheduledPackDatesBetween(
+  exclusiveStart: string,
+  exclusiveEnd: string,
+): Promise<string[]> {
+  if (!supabase) return [];
+  if (exclusiveStart >= exclusiveEnd) return [];
+  try {
+    const { data } = await supabase
+      .from("pack_schedule")
+      .select("date")
+      .gt("date", exclusiveStart)
+      .lt("date", exclusiveEnd);
+    return (data ?? []).map((r: { date: string }) => r.date);
+  } catch {
+    return [];
+  }
+}

--- a/src/pages/Pack/constants.ts
+++ b/src/pages/Pack/constants.ts
@@ -1,2 +1,5 @@
 export const PACK_SIZE = 10;
 export const MAX_GUESSES_PER_PLAYER = 3;
+export const PACK_DAY_ONE_DATE = "2026-05-04";
+export const PACK_RESULT_PREFIX = "football-nerdle-pack-";
+export const PACK_SHARE_URL = "https://spiritsack.github.io/football-nerdle/#/pack";

--- a/src/pages/Pack/constants.ts
+++ b/src/pages/Pack/constants.ts
@@ -3,3 +3,5 @@ export const MAX_GUESSES_PER_PLAYER = 3;
 export const PACK_DAY_ONE_DATE = "2026-05-04";
 export const PACK_RESULT_PREFIX = "football-nerdle-pack-";
 export const PACK_SHARE_URL = "https://spiritsack.github.io/football-nerdle/#/pack";
+export const PACK_STATS_KEY = "football-nerdle-pack-stats";
+export const PACK_STREAK_THRESHOLD = 7;

--- a/src/pages/Pack/helpers.ts
+++ b/src/pages/Pack/helpers.ts
@@ -1,0 +1,53 @@
+import { PACK_DAY_ONE_DATE, PACK_RESULT_PREFIX, PACK_SHARE_URL } from "./constants";
+import type { PackAttempt } from "./types";
+
+const MS_PER_DAY = 86_400_000;
+
+export function getPackDayNumber(date: string): number {
+  const start = new Date(`${PACK_DAY_ONE_DATE}T00:00:00Z`);
+  const current = new Date(`${date}T00:00:00Z`);
+  return Math.floor((current.getTime() - start.getTime()) / MS_PER_DAY) + 1;
+}
+
+export function getDateForPackDay(day: number): string {
+  const start = new Date(`${PACK_DAY_ONE_DATE}T00:00:00Z`);
+  start.setUTCDate(start.getUTCDate() + (day - 1));
+  return start.toISOString().slice(0, 10);
+}
+
+export interface SavedPackResult {
+  date: string;
+  score: number;
+  attempts: PackAttempt[];
+}
+
+export function savePackResult(result: SavedPackResult): void {
+  try {
+    localStorage.setItem(PACK_RESULT_PREFIX + result.date, JSON.stringify(result));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function loadPackResult(date: string): SavedPackResult | null {
+  try {
+    const raw = localStorage.getItem(PACK_RESULT_PREFIX + date);
+    if (!raw) return null;
+    return JSON.parse(raw) as SavedPackResult;
+  } catch {
+    return null;
+  }
+}
+
+export interface ShareInput {
+  date: string;
+  clubName: string;
+  score: number;
+  attempts: PackAttempt[];
+}
+
+export function buildShareText({ date, clubName, score, attempts }: ShareInput): string {
+  const dayNum = getPackDayNumber(date);
+  const grid = attempts.map((a) => (a.correct ? "✅" : "❌")).join("");
+  return `Football Nerdle Pack #${dayNum} — ${clubName} ${score}/10\n${grid}\n${PACK_SHARE_URL}`;
+}

--- a/src/pages/Pack/hints.ts
+++ b/src/pages/Pack/hints.ts
@@ -1,0 +1,35 @@
+import type { FormerTeam, PlayerWithTeams } from "../../types";
+
+export interface PackHints {
+  nationality?: string;
+  position?: string;
+  era?: string;
+  otherClub?: string;
+}
+
+export function deriveHints(
+  player: PlayerWithTeams,
+  packClubId: string,
+  wrongCount: number,
+): PackHints {
+  const hints: PackHints = {};
+  if (wrongCount >= 1 && player.nationality) hints.nationality = player.nationality;
+  if (wrongCount >= 2 && player.position) hints.position = player.position;
+  if (wrongCount >= 3) {
+    const era = formatEra(player.formerTeams.find((t) => t.teamId === packClubId));
+    if (era) hints.era = era;
+    const other = player.formerTeams.find((t) => t.teamId !== packClubId);
+    if (other) hints.otherClub = other.teamName;
+  }
+  return hints;
+}
+
+function formatEra(team: FormerTeam | undefined): string | undefined {
+  if (!team) return undefined;
+  const j = team.yearJoined?.trim();
+  const d = team.yearDeparted?.trim();
+  if (j && d) return `${j}–${d}`;
+  if (j) return `${j}–present`;
+  if (d) return `until ${d}`;
+  return undefined;
+}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -46,9 +46,36 @@ export default function Pack() {
         {status === "loading" && <p className="text-gray-400">Loading pack...</p>}
 
         {status === "idle" && (
-          <div role="alert" className="bg-orange-900/30 border border-orange-700 rounded-lg px-4 py-3 max-w-md w-full text-center text-orange-300 text-sm">
-            {error ?? "No pack available."}
-          </div>
+          <section
+            aria-label="No pack today"
+            className="flex flex-col items-center gap-4 max-w-md w-full text-center"
+          >
+            <div className="text-6xl" aria-hidden="true">📅</div>
+            <h2 className="text-2xl font-semibold">No pack today</h2>
+            <p className="text-gray-400 text-sm">
+              {error ?? "There is no pack scheduled for today."} Come back tomorrow, or try another mode.
+            </p>
+            <div className="flex gap-3 flex-wrap justify-center">
+              <Link
+                to="/guess"
+                className="px-5 py-2.5 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors"
+              >
+                Guess the Player
+              </Link>
+              <Link
+                to="/battle"
+                className="px-5 py-2.5 bg-gray-700 hover:bg-gray-600 rounded-lg font-semibold transition-colors"
+              >
+                Battle Mode
+              </Link>
+              <Link
+                to="/"
+                className="px-5 py-2.5 bg-gray-800 hover:bg-gray-700 rounded-lg font-semibold border border-gray-600 transition-colors"
+              >
+                Home
+              </Link>
+            </div>
+          </section>
         )}
 
         {pack && (status === "playing" || status === "revealing") && currentPlayer && (

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -7,7 +7,7 @@ import { deriveHints } from "./hints";
 import { buildShareText, getPackDayNumber } from "./helpers";
 
 export default function Pack() {
-  const { state, submitGuess } = usePackGame();
+  const { state, submitGuess, stats } = usePackGame();
   const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
   const currentPlayer = pack?.players[currentIndex] ?? null;
   const lastAttempt = attempts[attempts.length - 1];
@@ -121,6 +121,33 @@ export default function Pack() {
               <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
                 Back to Home
               </Link>
+            </div>
+
+            <div aria-label="Pack stats" className="bg-gray-800 border border-gray-600 rounded-xl p-6 max-w-md w-full">
+              <h3 className="text-lg font-semibold text-center text-gray-300 mb-4">Your Stats</h3>
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <div>
+                  <div className="text-2xl font-bold">{stats.played}</div>
+                  <div className="text-gray-400 text-xs">Played</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-green-400">{stats.bestScore}</div>
+                  <div className="text-gray-400 text-xs">Best</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-yellow-400">{stats.streak}</div>
+                  <div className="text-gray-400 text-xs">Streak</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-yellow-400">{stats.longestStreak}</div>
+                  <div className="text-gray-400 text-xs">Longest</div>
+                </div>
+              </div>
+              {stats.played > 0 && (
+                <div className="mt-3 text-center text-gray-400 text-sm">
+                  Avg: {(stats.totalScore / stats.played).toFixed(1)} / 10
+                </div>
+              )}
             </div>
           </>
         )}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { usePackGame } from "./usePackGame";
 import PlayerSearch from "../../components/PlayerSearch";
 import { MAX_GUESSES_PER_PLAYER } from "./constants";
 import { deriveHints } from "./hints";
+import { buildShareText, getPackDayNumber } from "./helpers";
 
 export default function Pack() {
   const { state, submitGuess } = usePackGame();
@@ -12,6 +14,21 @@ export default function Pack() {
   const hints = currentPlayer && pack
     ? deriveHints(currentPlayer, pack.club.id, wrongGuessesForCurrent.length)
     : null;
+  const [copied, setCopied] = useState(false);
+
+  function handleShare() {
+    if (!pack) return;
+    const text = buildShareText({
+      date: pack.date,
+      clubName: pack.club.name,
+      score,
+      attempts,
+    });
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col">
@@ -85,15 +102,26 @@ export default function Pack() {
 
         {status === "finished" && pack && (
           <>
-            <h2 className="text-3xl font-bold text-green-400">Pack complete!</h2>
-            <p className="text-2xl">
-              <span className="font-bold text-green-400">{score}</span>
-              <span className="text-gray-400"> / {pack.players.length}</span>
+            <p className="text-gray-300 text-lg">
+              {pack.club.name} · Pack #{getPackDayNumber(pack.date)}
             </p>
-            <ProgressStrip total={pack.players.length} attempts={attempts} currentIndex={currentIndex} />
-            <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
-              Back to Home
-            </Link>
+            <p className="text-7xl font-bold bg-gradient-to-br from-green-300 to-emerald-500 bg-clip-text text-transparent">
+              {score}<span className="text-gray-500">/{pack.players.length}</span>
+            </p>
+            <p className="text-2xl tracking-wide" aria-label="Result grid">
+              {attempts.map((a) => (a.correct ? "✅" : "❌")).join("")}
+            </p>
+            <div className="flex gap-3 flex-wrap justify-center">
+              <button
+                onClick={handleShare}
+                className="px-6 py-3 bg-blue-600 hover:bg-blue-500 rounded-lg font-semibold transition-colors"
+              >
+                {copied ? "Copied!" : "Share Result"}
+              </button>
+              <Link to="/" className="px-6 py-3 bg-green-600 hover:bg-green-500 rounded-lg font-semibold transition-colors">
+                Back to Home
+              </Link>
+            </div>
           </>
         )}
       </main>

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -2,12 +2,16 @@ import { Link } from "react-router-dom";
 import { usePackGame } from "./usePackGame";
 import PlayerSearch from "../../components/PlayerSearch";
 import { MAX_GUESSES_PER_PLAYER } from "./constants";
+import { deriveHints } from "./hints";
 
 export default function Pack() {
   const { state, submitGuess } = usePackGame();
   const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
   const currentPlayer = pack?.players[currentIndex] ?? null;
   const lastAttempt = attempts[attempts.length - 1];
+  const hints = currentPlayer && pack
+    ? deriveHints(currentPlayer, pack.club.id, wrongGuessesForCurrent.length)
+    : null;
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col">
@@ -65,6 +69,8 @@ export default function Pack() {
               )}
             </div>
 
+            {hints && <HintsList hints={hints} />}
+
             {status === "playing" && (
               <PlayerSearch onSelect={submitGuess} placeholder="Player name" hideThumbnails />
             )}
@@ -92,6 +98,25 @@ export default function Pack() {
         )}
       </main>
     </div>
+  );
+}
+
+function HintsList({ hints }: { hints: ReturnType<typeof deriveHints> }) {
+  const items: { label: string; value: string }[] = [];
+  if (hints.nationality) items.push({ label: "Nationality", value: hints.nationality });
+  if (hints.position) items.push({ label: "Position", value: hints.position });
+  if (hints.era) items.push({ label: "Era at this club", value: hints.era });
+  if (hints.otherClub) items.push({ label: "Also played for", value: hints.otherClub });
+  if (items.length === 0) return null;
+  return (
+    <dl aria-label="Hints" className="grid grid-cols-2 gap-x-4 gap-y-1 max-w-sm w-full text-sm">
+      {items.map((item) => (
+        <div key={item.label} className="contents">
+          <dt className="text-gray-400 text-right">{item.label}</dt>
+          <dd className="text-white font-medium">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 

--- a/src/pages/Pack/stats.ts
+++ b/src/pages/Pack/stats.ts
@@ -1,0 +1,63 @@
+import { PACK_STATS_KEY, PACK_STREAK_THRESHOLD } from "./constants";
+
+export interface PackStats {
+  played: number;
+  totalScore: number;
+  bestScore: number;
+  streak: number;
+  longestStreak: number;
+  lastPlayedDate?: string;
+  lastSuccessDate?: string;
+}
+
+export const DEFAULT_PACK_STATS: PackStats = {
+  played: 0,
+  totalScore: 0,
+  bestScore: 0,
+  streak: 0,
+  longestStreak: 0,
+};
+
+export function loadPackStats(): PackStats {
+  try {
+    const raw = localStorage.getItem(PACK_STATS_KEY);
+    if (!raw) return { ...DEFAULT_PACK_STATS };
+    return { ...DEFAULT_PACK_STATS, ...(JSON.parse(raw) as Partial<PackStats>) };
+  } catch {
+    return { ...DEFAULT_PACK_STATS };
+  }
+}
+
+function savePackStats(stats: PackStats): void {
+  try {
+    localStorage.setItem(PACK_STATS_KEY, JSON.stringify(stats));
+  } catch {
+    // ignore
+  }
+}
+
+export function recordPackResult(
+  prev: PackStats,
+  date: string,
+  score: number,
+  scheduledBetween: string[],
+  metThresholdAt: (date: string) => boolean,
+): PackStats {
+  const passed = score >= PACK_STREAK_THRESHOLD;
+  let nextStreak = 0;
+  if (passed) {
+    const noBrokenScheduledGap = scheduledBetween.every((d) => metThresholdAt(d));
+    nextStreak = noBrokenScheduledGap ? prev.streak + 1 : 1;
+  }
+  const next: PackStats = {
+    played: prev.played + 1,
+    totalScore: prev.totalScore + score,
+    bestScore: Math.max(prev.bestScore, score),
+    streak: nextStreak,
+    longestStreak: Math.max(prev.longestStreak, nextStreak),
+    lastPlayedDate: date,
+    lastSuccessDate: passed ? date : prev.lastSuccessDate,
+  };
+  savePackStats(next);
+  return next;
+}

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
-import { getPackForDate } from "../../api/packSchedule";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getPackForDate, getScheduledPackDatesBetween } from "../../api/packSchedule";
 import type { Player } from "../../types";
 import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
 import type { PackGameState } from "./types";
 import { getTodayString } from "../../utils/dates";
 import { loadPackResult, savePackResult } from "./helpers";
+import { DEFAULT_PACK_STATS, loadPackStats, recordPackResult } from "./stats";
+import { PACK_STREAK_THRESHOLD } from "./constants";
+import type { PackStats } from "./stats";
 
 const REVEAL_MS = 1500;
 
@@ -22,6 +25,8 @@ const EMPTY: PackGameState = {
 export function usePackGame() {
   const [today] = useState(getTodayString);
   const [state, setState] = useState<PackGameState>(EMPTY);
+  const [stats, setStats] = useState<PackStats>(DEFAULT_PACK_STATS);
+  const recordedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -33,8 +38,10 @@ export function usePackGame() {
           setState({ ...EMPTY, status: "idle", error: "No pack scheduled for today." });
           return;
         }
+        setStats(loadPackStats());
         const stored = loadPackResult(today);
         if (stored && stored.attempts.length === pack.players.length) {
+          recordedRef.current = true;
           setState({
             ...initialState(pack),
             status: "finished",
@@ -61,6 +68,23 @@ export function usePackGame() {
       score: state.score,
       attempts: state.attempts,
     });
+
+    if (recordedRef.current) return;
+    recordedRef.current = true;
+    const date = state.pack.date;
+    const score = state.score;
+    const prior = loadPackStats();
+
+    (async () => {
+      const between = prior.lastSuccessDate
+        ? await getScheduledPackDatesBetween(prior.lastSuccessDate, date)
+        : [];
+      const updated = recordPackResult(prior, date, score, between, (d) => {
+        const r = loadPackResult(d);
+        return !!r && r.score >= PACK_STREAK_THRESHOLD;
+      });
+      setStats(updated);
+    })();
   }, [state.status, state.pack, state.score, state.attempts]);
 
   const submitGuess = useCallback((guess: Player) => {
@@ -79,5 +103,5 @@ export function usePackGame() {
     return () => clearTimeout(id);
   }, [state.status, state.currentIndex]);
 
-  return { state, submitGuess, advance, today };
+  return { state, submitGuess, advance, today, stats };
 }

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -4,6 +4,7 @@ import type { Player } from "../../types";
 import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
 import type { PackGameState } from "./types";
 import { getTodayString } from "../../utils/dates";
+import { loadPackResult, savePackResult } from "./helpers";
 
 const REVEAL_MS = 1500;
 
@@ -32,6 +33,17 @@ export function usePackGame() {
           setState({ ...EMPTY, status: "idle", error: "No pack scheduled for today." });
           return;
         }
+        const stored = loadPackResult(today);
+        if (stored && stored.attempts.length === pack.players.length) {
+          setState({
+            ...initialState(pack),
+            status: "finished",
+            attempts: stored.attempts,
+            score: stored.score,
+            currentIndex: pack.players.length,
+          });
+          return;
+        }
         setState(initialState(pack));
       } catch (e) {
         if (cancelled) return;
@@ -41,6 +53,15 @@ export function usePackGame() {
     })();
     return () => { cancelled = true; };
   }, [today]);
+
+  useEffect(() => {
+    if (state.status !== "finished" || !state.pack) return;
+    savePackResult({
+      date: state.pack.date,
+      score: state.score,
+      attempts: state.attempts,
+    });
+  }, [state.status, state.pack, state.score, state.attempts]);
 
   const submitGuess = useCallback((guess: Player) => {
     setState((s) => reduceGuess(s, guess));


### PR DESCRIPTION
## Summary
Bundles four slices that were originally stacked PRs (#51, #52, #53 each merged into their parent feature branches but not main). Retargeting this PR's base to \`main\` collapses the chain into a single cumulative diff:

- **Slice 02 — progressive hints**: pure \`deriveHints(player, packClubId, wrongCount)\` reveals nationality (1 wrong), position (2 wrong), era at pack club + one other career club (3 wrong). Renders under the photo.
- **Slice 03 — score grid + share + persist**: gradient \`N/10\`, club name, pack-scoped day number, single-line emoji grid (✅/❌). "Share Result" button. Per-day result persists to \`football-nerdle-pack-YYYY-MM-DD\`. Revisits show completed state.
- **Slice 04 — stats + gap-aware streak**: \`football-nerdle-pack-stats\` tracks played, totalScore, bestScore, streak, longestStreak, lastPlayedDate, lastSuccessDate. Streak advances on score >=7, **survives** unscheduled-day gaps, **breaks** on missed scheduled days. Stats panel renders on the finished screen.
- **Slice 06 — no-pack-today fallback**: replaces the bare idle alert with a centered "No pack today" screen linking to other modes. Streak is preserved across unscheduled visits.

(Slice 05 / leaderboard remains independently doable; slice 07 / home card is queued in PR #55.)

## Test plan
- [ ] \`npm test\` — 24 new unit tests across hints, helpers, and stats
- [ ] \`npm run test:e2e -- e2e/pack-*.spec.ts\` — 8 pack e2e specs (tracer, hints, share, stats, no-pack-fallback)
- [ ] Manual: play a pack, see hints accumulate, complete to N/10, share, refresh — completed state persists; visit on a date without seed → friendly fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)