### PR TITLE
feat: pack mode leaderboard distribution (slice 05)

### DIFF
--- a/e2e/pack-leaderboard.spec.ts
+++ b/e2e/pack-leaderboard.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pack mode leaderboard", () => {
+  test("renders the bar chart with the user's score bucket highlighted", async ({ page }) => {
+    await page.goto("/#/pack");
+    const ready = await page.getByPlaceholder("Player name").waitFor({ state: "visible", timeout: 15_000 }).then(() => true).catch(() => false);
+    if (!ready) {
+      test.skip(true, "No pack seeded for today.");
+      return;
+    }
+
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    });
+
+    // Pre-populate a finished pack so the leaderboard renders, AND mark the
+    // result as already submitted so we don't pollute production with a real insert.
+    await page.evaluate((date) => {
+      const attempts = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i + 1}`,
+        correct: i < 7,
+        guesses: i < 7 ? 1 : 3,
+      }));
+      localStorage.setItem(
+        `football-nerdle-pack-${date}`,
+        JSON.stringify({ date, score: 7, attempts }),
+      );
+      localStorage.setItem(`football-nerdle-pack-lb-${date}`, "1");
+    }, today);
+
+    await page.goto("/#/pack");
+
+    const board = page.getByLabel("Today's results");
+    await expect(board).toBeVisible({ timeout: 15_000 });
+
+    // The user's bucket (7/10) is rendered with bold styling.
+    const userRow = board.locator("div").filter({ hasText: /^7\/10/ }).first();
+    await expect(userRow).toBeVisible();
+
+    // All 11 buckets are rendered (0/10 through 10/10).
+    for (const score of [0, 1, 5, 7, 10]) {
+      await expect(board.getByText(`${score}/10`, { exact: true })).toBeVisible();
+    }
+  });
+});

--- a/e2e/pack-share.spec.ts
+++ b/e2e/pack-share.spec.ts
@@ -33,7 +33,7 @@ test.describe("Pack mode score & share", () => {
 
     // Finished screen appears in place of the play UI.
     await expect(page.getByText(/Pack #\d+/)).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("7/10")).toBeVisible();
+    await expect(page.getByText(/7\/10/).first()).toBeVisible();
     await expect(page.getByLabel("Result grid")).toContainText("✅");
     await expect(page.getByLabel("Result grid")).toContainText("❌");
     await expect(page.getByRole("button", { name: /Share Result/ })).toBeVisible();

--- a/src/api/packLeaderboard.ts
+++ b/src/api/packLeaderboard.ts
@@ -1,0 +1,62 @@
+import { supabase } from "./supabaseClient";
+import type { PackAttempt } from "../pages/Pack/types";
+
+const PACK_LB_PREFIX = "football-nerdle-pack-lb-";
+
+function getSubmittedKey(date: string): string {
+  return PACK_LB_PREFIX + date;
+}
+
+export function hasSubmittedPackResult(date: string): boolean {
+  try {
+    return localStorage.getItem(getSubmittedKey(date)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export async function submitPackResult(
+  date: string,
+  score: number,
+  attempts: PackAttempt[],
+): Promise<void> {
+  if (!supabase) return;
+  if (hasSubmittedPackResult(date)) return;
+
+  const { error } = await supabase
+    .from("pack_results")
+    .insert({ date, score, attempts_json: attempts });
+
+  if (!error) {
+    try {
+      localStorage.setItem(getSubmittedKey(date), "1");
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export interface PackLeaderboardEntry {
+  score: number;
+  count: number;
+}
+
+export async function getPackLeaderboard(date: string): Promise<PackLeaderboardEntry[]> {
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from("pack_results")
+    .select("score")
+    .eq("date", date);
+
+  if (error || !data) return [];
+
+  const counts = new Map<number, number>();
+  for (const row of data) {
+    counts.set(row.score, (counts.get(row.score) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .map(([score, count]) => ({ score, count }))
+    .sort((a, b) => a.score - b.score);
+}

--- a/src/components/PackLeaderboard/index.tsx
+++ b/src/components/PackLeaderboard/index.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { getPackLeaderboard, type PackLeaderboardEntry } from "../../api/packLeaderboard";
+
+const ALL_BUCKETS = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
+
+interface Props {
+  date: string;
+  userScore: number;
+}
+
+export default function PackLeaderboard({ date, userScore }: Props) {
+  const [entries, setEntries] = useState<PackLeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getPackLeaderboard(date).then((data) => {
+      setEntries(data);
+      setLoading(false);
+    });
+  }, [date]);
+
+  if (loading) return null;
+
+  const countMap = new Map(entries.map((e) => [e.score, e.count]));
+
+  // Optimistically include the user's score if not yet present.
+  if ((countMap.get(userScore) ?? 0) === 0) {
+    countMap.set(userScore, 1);
+  }
+
+  const total = [...countMap.values()].reduce((sum, c) => sum + c, 0);
+  const maxCount = Math.max(...ALL_BUCKETS.map((b) => countMap.get(b) ?? 0), 1);
+
+  if (total === 0) return null;
+
+  return (
+    <div aria-label="Today's results" className="bg-gray-800 border border-gray-600 rounded-xl p-6 max-w-md w-full">
+      <h3 className="text-lg font-semibold text-center text-gray-300 mb-4">Today's Results</h3>
+      <div className="space-y-2">
+        {ALL_BUCKETS.map((bucket) => {
+          const count = countMap.get(bucket) ?? 0;
+          const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+          const barWidth = maxCount > 0 ? (count / maxCount) * 100 : 0;
+          const isUser = bucket === userScore;
+
+          return (
+            <div key={bucket} className="flex items-center gap-3">
+              <span className={`text-xs w-12 shrink-0 text-right ${isUser ? "text-white font-bold" : "text-gray-400"}`}>
+                {bucket}/10
+              </span>
+              <div className="flex-1 h-6 bg-gray-700 rounded overflow-hidden relative">
+                <div
+                  className={`h-full rounded transition-all duration-500 ${
+                    isUser ? "bg-green-500" : "bg-green-900/60"
+                  }`}
+                  style={{ width: `${barWidth}%` }}
+                />
+              </div>
+              <span className={`text-xs w-14 shrink-0 ${isUser ? "text-white font-bold" : "text-gray-500"}`}>
+                {count} <span className="text-gray-600">({pct}%)</span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -5,6 +5,7 @@ import PlayerSearch from "../../components/PlayerSearch";
 import { MAX_GUESSES_PER_PLAYER } from "./constants";
 import { deriveHints } from "./hints";
 import { buildShareText, getPackDayNumber } from "./helpers";
+import PackLeaderboard from "../../components/PackLeaderboard";
 
 export default function Pack() {
   const { state, submitGuess, stats } = usePackGame();
@@ -176,6 +177,8 @@ export default function Pack() {
                 </div>
               )}
             </div>
+
+            <PackLeaderboard date={pack.date} userScore={score} />
           </>
         )}
       </main>

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -8,6 +8,7 @@ import { loadPackResult, savePackResult } from "./helpers";
 import { DEFAULT_PACK_STATS, loadPackStats, recordPackResult } from "./stats";
 import { PACK_STREAK_THRESHOLD } from "./constants";
 import type { PackStats } from "./stats";
+import { submitPackResult } from "../../api/packLeaderboard";
 
 const REVEAL_MS = 1500;
 
@@ -73,6 +74,7 @@ export function usePackGame() {
     recordedRef.current = true;
     const date = state.pack.date;
     const score = state.score;
+    const attempts = state.attempts;
     const prior = loadPackStats();
 
     (async () => {
@@ -84,6 +86,7 @@ export function usePackGame() {
         return !!r && r.score >= PACK_STREAK_THRESHOLD;
       });
       setStats(updated);
+      submitPackResult(date, score, attempts);
     })();
   }, [state.status, state.pack, state.score, state.attempts]);
 


### PR DESCRIPTION
## Summary
- Submits completed packs to \`pack_results\` (anon insert, RLS already in place from migration 012)
- Client-side dedupe via \`football-nerdle-pack-lb-YYYY-MM-DD\` so refresh doesn't double-count
- New \`PackLeaderboard\` component renders 11 bars (0/10 → 10/10) with the user's bucket highlighted; optimistically includes the user's score if not yet present in the fetched data
- Mirrors the existing \`dailyLeaderboard\` pattern (api shape, dedupe key strategy, optimistic include)

Stacks on PR #55 (slice 07 / home card). Per \`.scratch/pack-mode/issues/05-leaderboard-distribution.md\`.

## Test plan
- [ ] \`npm run test:e2e -- e2e/pack-leaderboard.spec.ts\` — bar chart renders with user's score bucket
- [ ] Manual: complete a pack on staging, see leaderboard render and your score bar highlighted; refresh — no double-submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)