### PR TITLE
feat: pack admin slices 08 + 09 (publish form + candidate panel)

### DIFF
--- a/e2e/pack-admin.spec.ts
+++ b/e2e/pack-admin.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+
+const ADMIN_EMAIL = process.env.PACK_ADMIN_EMAIL;
+const ADMIN_PASSWORD = process.env.PACK_ADMIN_PASSWORD;
+
+test.describe("Admin Pack Builder", () => {
+  test("Pack Builder tab renders the publish form (no auth required for tab-render check)", async ({ page }) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      test.skip(true, "Set PACK_ADMIN_EMAIL/PACK_ADMIN_PASSWORD to run admin e2e.");
+      return;
+    }
+
+    await page.goto("/#/admin");
+    await page.getByPlaceholder("Email").fill(ADMIN_EMAIL);
+    await page.getByPlaceholder("Password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    // Switch to Pack Builder tab.
+    await page.getByRole("tab", { name: "Pack Builder" }).click();
+
+    const builder = page.getByLabel("Pack Builder");
+    await expect(builder).toBeVisible();
+
+    // Date input + club input + 10 player slots.
+    await expect(builder.getByLabel("Date")).toBeVisible();
+    await expect(builder.getByLabel("Club")).toBeVisible();
+    await expect(builder.getByPlaceholder("Player 1")).toBeVisible();
+    await expect(builder.getByPlaceholder("Player 10")).toBeVisible();
+
+    // Publish button is disabled until 10 players + club are selected.
+    const publishBtn = builder.getByRole("button", { name: /Publish Pack/ });
+    await expect(publishBtn).toBeDisabled();
+    await expect(builder.getByText(/Pick a club|Need 10 players/)).toBeVisible();
+  });
+
+  test("publish flow: build pack and verify it plays on /pack", async ({ page }) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      test.skip(true, "Set PACK_ADMIN_EMAIL/PACK_ADMIN_PASSWORD to run admin e2e.");
+      return;
+    }
+
+    // Mock supabase pack_schedule insert so the test doesn't pollute prod data.
+    await page.route(/\/rest\/v1\/pack_schedule(\?.*)?$/, (route) => {
+      const method = route.request().method();
+      if (method === "POST") {
+        return route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify([{ date: "2099-01-01" }]),
+        });
+      }
+      // Pretend nothing is scheduled for the picked date.
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto("/#/admin");
+    await page.getByPlaceholder("Email").fill(ADMIN_EMAIL);
+    await page.getByPlaceholder("Password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await page.getByRole("tab", { name: "Pack Builder" }).click();
+
+    // Pick a club: search for a known top club.
+    const builder = page.getByLabel("Pack Builder");
+    const clubInput = builder.getByPlaceholder("Search clubs...");
+    await clubInput.fill("Liverpool");
+    const clubOption = page.getByRole("listbox").getByRole("button").first();
+    await clubOption.waitFor({ state: "visible", timeout: 5_000 });
+    await clubOption.click();
+
+    // Fill 10 players via the per-row search.
+    const knownPlayers = ["Lewandowski", "Messi", "Ronaldo", "Mbappe", "Haaland", "Salah", "Modric", "Kane", "Benzema", "De Bruyne"];
+    for (let i = 0; i < 10; i++) {
+      const slot = builder.getByPlaceholder(`Player ${i + 1}`);
+      if (!(await slot.isVisible().catch(() => false))) break;
+      await slot.fill(knownPlayers[i]);
+      const opt = page.getByRole("option").first();
+      const ok = await opt.waitFor({ state: "visible", timeout: 3_000 }).then(() => true).catch(() => false);
+      if (!ok) break;
+      await opt.click();
+    }
+
+    const publishBtn = builder.getByRole("button", { name: /Publish Pack/ });
+    if (await publishBtn.isDisabled()) {
+      test.skip(true, "Could not auto-fill 10 valid players from the search results.");
+      return;
+    }
+
+    await publishBtn.click();
+    await expect(builder.getByRole("status")).toContainText(/Pack published/);
+  });
+});

--- a/e2e/pack-admin.spec.ts
+++ b/e2e/pack-admin.spec.ts
@@ -4,7 +4,7 @@ const ADMIN_EMAIL = process.env.PACK_ADMIN_EMAIL;
 const ADMIN_PASSWORD = process.env.PACK_ADMIN_PASSWORD;
 
 test.describe("Admin Pack Builder", () => {
-  test("Pack Builder tab renders the publish form (no auth required for tab-render check)", async ({ page }) => {
+  test("Pack Builder tab renders the form, candidates appear after picking a club", async ({ page }) => {
     if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
       test.skip(true, "Set PACK_ADMIN_EMAIL/PACK_ADMIN_PASSWORD to run admin e2e.");
       return;
@@ -15,31 +15,39 @@ test.describe("Admin Pack Builder", () => {
     await page.getByPlaceholder("Password").fill(ADMIN_PASSWORD);
     await page.getByRole("button", { name: "Sign In" }).click();
 
-    // Switch to Pack Builder tab.
     await page.getByRole("tab", { name: "Pack Builder" }).click();
-
     const builder = page.getByLabel("Pack Builder");
     await expect(builder).toBeVisible();
-
-    // Date input + club input + 10 player slots.
     await expect(builder.getByLabel("Date")).toBeVisible();
-    await expect(builder.getByLabel("Club")).toBeVisible();
-    await expect(builder.getByPlaceholder("Player 1")).toBeVisible();
-    await expect(builder.getByPlaceholder("Player 10")).toBeVisible();
 
-    // Publish button is disabled until 10 players + club are selected.
+    // Publish disabled until conditions met.
     const publishBtn = builder.getByRole("button", { name: /Publish Pack/ });
     await expect(publishBtn).toBeDisabled();
-    await expect(builder.getByText(/Pick a club|Need 10 players/)).toBeVisible();
+
+    // Pick a club; candidate panel should populate.
+    const clubInput = builder.getByPlaceholder("Search clubs...");
+    await clubInput.fill("Liverpool");
+    const clubOption = page.getByRole("listbox").getByRole("button").first();
+    await clubOption.waitFor({ state: "visible", timeout: 5_000 });
+    await clubOption.click();
+
+    const candidatesPanel = builder.getByLabel("Candidates");
+    await expect(candidatesPanel).toBeVisible();
+    await expect(candidatesPanel.getByRole("button", { name: /^Add / }).first()).toBeVisible({ timeout: 10_000 });
+
+    // Selected panel shows 10 empty slots.
+    const selected = builder.getByLabel("Selected");
+    await expect(selected.getByText("0 / 10")).toBeVisible();
+    await expect(selected.getByText("empty slot")).toHaveCount(10);
   });
 
-  test("publish flow: build pack and verify it plays on /pack", async ({ page }) => {
+  test("publish flow: rank candidates, add 10, publish", async ({ page }) => {
     if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
       test.skip(true, "Set PACK_ADMIN_EMAIL/PACK_ADMIN_PASSWORD to run admin e2e.");
       return;
     }
 
-    // Mock supabase pack_schedule insert so the test doesn't pollute prod data.
+    // Mock pack_schedule writes and conflict-check so we don't pollute data.
     await page.route(/\/rest\/v1\/pack_schedule(\?.*)?$/, (route) => {
       const method = route.request().method();
       if (method === "POST") {
@@ -49,7 +57,6 @@ test.describe("Admin Pack Builder", () => {
           body: JSON.stringify([{ date: "2099-01-01" }]),
         });
       }
-      // Pretend nothing is scheduled for the picked date.
       return route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -63,8 +70,6 @@ test.describe("Admin Pack Builder", () => {
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await page.getByRole("tab", { name: "Pack Builder" }).click();
-
-    // Pick a club: search for a known top club.
     const builder = page.getByLabel("Pack Builder");
     const clubInput = builder.getByPlaceholder("Search clubs...");
     await clubInput.fill("Liverpool");
@@ -72,21 +77,20 @@ test.describe("Admin Pack Builder", () => {
     await clubOption.waitFor({ state: "visible", timeout: 5_000 });
     await clubOption.click();
 
-    // Fill 10 players via the per-row search.
-    const knownPlayers = ["Lewandowski", "Messi", "Ronaldo", "Mbappe", "Haaland", "Salah", "Modric", "Kane", "Benzema", "De Bruyne"];
+    const candidatesPanel = builder.getByLabel("Candidates");
+    await candidatesPanel.getByRole("button", { name: /^Add / }).first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Add the top 10 candidates.
     for (let i = 0; i < 10; i++) {
-      const slot = builder.getByPlaceholder(`Player ${i + 1}`);
-      if (!(await slot.isVisible().catch(() => false))) break;
-      await slot.fill(knownPlayers[i]);
-      const opt = page.getByRole("option").first();
-      const ok = await opt.waitFor({ state: "visible", timeout: 3_000 }).then(() => true).catch(() => false);
+      const enabledAdd = candidatesPanel.getByRole("button", { name: /^Add / }).filter({ hasNotText: "Added" }).first();
+      const ok = await enabledAdd.waitFor({ state: "visible", timeout: 3_000 }).then(() => true).catch(() => false);
       if (!ok) break;
-      await opt.click();
+      await enabledAdd.click();
     }
 
     const publishBtn = builder.getByRole("button", { name: /Publish Pack/ });
     if (await publishBtn.isDisabled()) {
-      test.skip(true, "Could not auto-fill 10 valid players from the search results.");
+      test.skip(true, "Fewer than 10 ranked candidates available for the picked club.");
       return;
     }
 

--- a/src/__tests__/packBuilderValidation.test.ts
+++ b/src/__tests__/packBuilderValidation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { validatePackForPublish } from "../pages/Admin/packBuilderValidation";
+import type { Player } from "../types";
+
+function makePlayer(id: string, thumbnail = "https://example.com/x.jpg"): Player {
+  return { id, name: `Player ${id}`, thumbnail, nationality: "Brazil" };
+}
+
+const FUTURE_DATE = "2099-01-01";
+
+function tenPlayers(): Player[] {
+  return Array.from({ length: 10 }, (_, i) => makePlayer(`p${i + 1}`));
+}
+
+describe("validatePackForPublish", () => {
+  it("rejects when no club is picked", () => {
+    const r = validatePackForPublish({
+      clubId: null,
+      players: tenPlayers(),
+      date: FUTURE_DATE,
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/club/i);
+  });
+
+  it("rejects when date is missing", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: "",
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/date/i);
+  });
+
+  it("rejects when date is in the past", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: "2000-01-01",
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/today or future/i);
+  });
+
+  it("rejects when the date already has a pack scheduled", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: FUTURE_DATE,
+      alreadyScheduled: true,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/already scheduled/i);
+  });
+
+  it("rejects when fewer than 10 players are selected", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: [...tenPlayers().slice(0, 5), null, null, null, null, null],
+      date: FUTURE_DATE,
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Need 10 players/);
+  });
+
+  it("rejects when a selected player has no thumbnail", () => {
+    const players = tenPlayers();
+    players[3] = { ...players[3], thumbnail: "" };
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players,
+      date: FUTURE_DATE,
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/no photo/i);
+  });
+
+  it("rejects on duplicate player ids", () => {
+    const players = tenPlayers();
+    players[5] = makePlayer("p1");  // duplicate of slot 0
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players,
+      date: FUTURE_DATE,
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/duplicate/i);
+  });
+
+  it("passes when all conditions are met", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: FUTURE_DATE,
+      alreadyScheduled: false,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBeUndefined();
+  });
+});

--- a/src/__tests__/packCandidateRanker.test.ts
+++ b/src/__tests__/packCandidateRanker.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { rankClubCandidates, type CandidateInput } from "../pages/Admin/packCandidateRanker";
+
+function makeInput(overrides: Partial<CandidateInput> = {}): CandidateInput {
+  return {
+    id: "p1",
+    name: "Player One",
+    thumbnail: "https://x/p1.jpg",
+    stints: [{ yearJoined: "2018", yearDeparted: "2024", isLoan: false, isYouth: false }],
+    hasTopLeagueElsewhere: false,
+    ...overrides,
+  };
+}
+
+const NO_SEED = new Set<string>();
+
+describe("rankClubCandidates", () => {
+  it("returns an empty array for empty input", () => {
+    expect(rankClubCandidates([], NO_SEED)).toEqual([]);
+  });
+
+  it("excludes players with no non-youth stints", () => {
+    const input = [
+      makeInput({ id: "p1" }),
+      makeInput({
+        id: "youth-only",
+        stints: [{ yearJoined: "2010", yearDeparted: "2014", isLoan: false, isYouth: true }],
+      }),
+    ];
+    const ranked = rankClubCandidates(input, NO_SEED);
+    expect(ranked.map((r) => r.id)).toEqual(["p1"]);
+  });
+
+  it("excludes players without a thumbnail", () => {
+    const input = [
+      makeInput({ id: "p1" }),
+      makeInput({ id: "no-thumb", thumbnail: "" }),
+    ];
+    const ranked = rankClubCandidates(input, NO_SEED);
+    expect(ranked.map((r) => r.id)).toEqual(["p1"]);
+  });
+
+  it("ranks longer tenure higher than shorter tenure", () => {
+    const input = [
+      makeInput({ id: "short", stints: [{ yearJoined: "2022", yearDeparted: "2024", isLoan: false, isYouth: false }] }),
+      makeInput({ id: "long", stints: [{ yearJoined: "2010", yearDeparted: "2024", isLoan: false, isYouth: false }] }),
+    ];
+    const ranked = rankClubCandidates(input, NO_SEED);
+    expect(ranked.map((r) => r.id)).toEqual(["long", "short"]);
+  });
+
+  it("seed-list bonus boosts a player above a slightly-longer-tenure non-seed player", () => {
+    const input = [
+      // Non-seed with 7-year tenure → score = 7
+      makeInput({ id: "long", stints: [{ yearJoined: "2017", yearDeparted: "2024", isLoan: false, isYouth: false }] }),
+      // Seed with 5-year tenure → score = 5 + SEED_BONUS (>= 6 to beat 7)
+      makeInput({ id: "seed", stints: [{ yearJoined: "2019", yearDeparted: "2024", isLoan: false, isYouth: false }] }),
+    ];
+    const ranked = rankClubCandidates(input, new Set(["seed"]));
+    expect(ranked[0].id).toBe("seed");
+  });
+
+  it("top-5-league bonus boosts otherwise-equal players", () => {
+    const input = [
+      makeInput({ id: "no-top" }),
+      makeInput({ id: "top-league", hasTopLeagueElsewhere: true }),
+    ];
+    const ranked = rankClubCandidates(input, NO_SEED);
+    expect(ranked[0].id).toBe("top-league");
+  });
+
+  it("loan penalty drops a player with any loan stint below a non-loan equivalent", () => {
+    const input = [
+      makeInput({ id: "permanent" }),
+      makeInput({
+        id: "loaned",
+        stints: [
+          { yearJoined: "2018", yearDeparted: "2020", isLoan: false, isYouth: false },
+          { yearJoined: "2022", yearDeparted: "2024", isLoan: true, isYouth: false },
+        ],
+      }),
+    ];
+    const ranked = rankClubCandidates(input, NO_SEED);
+    expect(ranked[0].id).toBe("permanent");
+  });
+
+  it("respects an optional limit", () => {
+    const input = Array.from({ length: 50 }, (_, i) => makeInput({ id: `p${i}` }));
+    const ranked = rankClubCandidates(input, NO_SEED, { limit: 30 });
+    expect(ranked).toHaveLength(30);
+  });
+
+  it("derives a tenure label spanning the first join and last departure across non-youth stints", () => {
+    const ranked = rankClubCandidates(
+      [
+        makeInput({
+          id: "p1",
+          stints: [
+            { yearJoined: "2010", yearDeparted: "2014", isLoan: false, isYouth: false },
+            { yearJoined: "2020", yearDeparted: "2024", isLoan: false, isYouth: false },
+          ],
+        }),
+      ],
+      NO_SEED,
+    );
+    expect(ranked[0].tenureLabel).toBe("2010–2024");
+  });
+
+  it("handles ongoing stints (no yearDeparted) by labeling 'present'", () => {
+    const ranked = rankClubCandidates(
+      [
+        makeInput({
+          id: "p1",
+          stints: [{ yearJoined: "2018", yearDeparted: "", isLoan: false, isYouth: false }],
+        }),
+      ],
+      NO_SEED,
+    );
+    expect(ranked[0].tenureLabel).toMatch(/2018–present/);
+  });
+});

--- a/src/api/packAdminApi.ts
+++ b/src/api/packAdminApi.ts
@@ -1,4 +1,14 @@
 import { supabase } from "./supabaseClient";
+import type { CandidateInput } from "../pages/Admin/packCandidateRanker";
+
+const TOP_LEAGUE_NAMES = new Set([
+  "Premier League",
+  "LaLiga",
+  "La Liga",
+  "Serie A",
+  "Bundesliga",
+  "Ligue 1",
+]);
 
 export async function isPackScheduled(date: string): Promise<boolean> {
   if (!supabase) return false;
@@ -30,4 +40,70 @@ export async function publishPack(
 
   if (error) return { ok: false, error: error.message };
   return { ok: true };
+}
+
+interface ClubMembershipRow {
+  player_id: string;
+  year_joined: string;
+  year_departed: string;
+  is_loan: boolean | null;
+  is_youth_team: boolean | null;
+  is_hidden: boolean | null;
+  players: { id: string; name: string; thumbnail: string } | null;
+}
+
+interface OtherClubRow {
+  player_id: string;
+  clubs: { league: string | null } | null;
+}
+
+export async function getClubCandidatePool(clubId: string): Promise<CandidateInput[]> {
+  if (!supabase) return [];
+
+  const { data: memberships, error } = await supabase
+    .from("player_clubs")
+    .select("player_id, year_joined, year_departed, is_loan, is_youth_team, is_hidden, players(id, name, thumbnail)")
+    .eq("club_id", clubId);
+
+  if (error || !memberships) return [];
+
+  const rows = memberships as unknown as ClubMembershipRow[];
+  const playerIds = Array.from(new Set(rows.map((r) => r.player_id)));
+  if (playerIds.length === 0) return [];
+
+  // Fetch other-club leagues to flag top-5-league careers.
+  const { data: otherClubs } = await supabase
+    .from("player_clubs")
+    .select("player_id, clubs(league)")
+    .in("player_id", playerIds)
+    .neq("club_id", clubId);
+
+  const topLeagueByPlayer = new Set<string>();
+  for (const r of (otherClubs as unknown as OtherClubRow[] | null) ?? []) {
+    if (r.clubs?.league && TOP_LEAGUE_NAMES.has(r.clubs.league)) {
+      topLeagueByPlayer.add(r.player_id);
+    }
+  }
+
+  const byPlayer = new Map<string, CandidateInput>();
+  for (const row of rows) {
+    if (row.is_hidden) continue;
+    if (!row.players) continue;
+    const existing = byPlayer.get(row.player_id) ?? {
+      id: row.players.id,
+      name: row.players.name,
+      thumbnail: row.players.thumbnail || "",
+      stints: [],
+      hasTopLeagueElsewhere: topLeagueByPlayer.has(row.player_id),
+    };
+    existing.stints.push({
+      yearJoined: row.year_joined ?? "",
+      yearDeparted: row.year_departed ?? "",
+      isLoan: !!row.is_loan,
+      isYouth: !!row.is_youth_team,
+    });
+    byPlayer.set(row.player_id, existing);
+  }
+
+  return Array.from(byPlayer.values());
 }

--- a/src/api/packAdminApi.ts
+++ b/src/api/packAdminApi.ts
@@ -1,0 +1,33 @@
+import { supabase } from "./supabaseClient";
+
+export async function isPackScheduled(date: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { data, error } = await supabase
+    .from("pack_schedule")
+    .select("date")
+    .eq("date", date)
+    .maybeSingle();
+  return !error && !!data;
+}
+
+export interface PublishPackResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function publishPack(
+  date: string,
+  clubId: string,
+  playerIds: string[],
+): Promise<PublishPackResult> {
+  if (!supabase) return { ok: false, error: "Supabase unavailable" };
+  if (playerIds.length !== 10) return { ok: false, error: "Pack must have exactly 10 players" };
+  if (new Set(playerIds).size !== 10) return { ok: false, error: "Player list contains duplicates" };
+
+  const { error } = await supabase
+    .from("pack_schedule")
+    .insert({ date, club_id: clubId, player_ids: playerIds });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}

--- a/src/pages/Admin/PackBuilder.tsx
+++ b/src/pages/Admin/PackBuilder.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react";
+import PlayerSearch from "../../components/PlayerSearch";
+import { searchClubs } from "../../api/adminApi";
+import { isPackScheduled, publishPack } from "../../api/packAdminApi";
+import { validatePackForPublish, type PackBuilderState } from "./packBuilderValidation";
+import type { Player } from "../../types";
+
+const PACK_SIZE = 10;
+const EMPTY_SLOTS: (Player | null)[] = Array(PACK_SIZE).fill(null);
+
+interface ClubOption {
+  id: string;
+  name: string;
+  badge: string;
+}
+
+function getDefaultDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function PackBuilder() {
+  const [club, setClub] = useState<ClubOption | null>(null);
+  const [clubQuery, setClubQuery] = useState("");
+  const [clubResults, setClubResults] = useState<ClubOption[]>([]);
+  const [players, setPlayers] = useState<(Player | null)[]>(EMPTY_SLOTS);
+  const [date, setDate] = useState<string>(getDefaultDate);
+  const [alreadyScheduled, setAlreadyScheduled] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [publishMessage, setPublishMessage] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
+
+  // Search clubs
+  useEffect(() => {
+    if (clubQuery.trim().length < 2) {
+      setClubResults([]);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      const results = await searchClubs(clubQuery.trim());
+      setClubResults(results);
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [clubQuery]);
+
+  // Check date conflict
+  useEffect(() => {
+    let cancelled = false;
+    if (!date) {
+      setAlreadyScheduled(false);
+      return;
+    }
+    isPackScheduled(date).then((scheduled) => {
+      if (!cancelled) setAlreadyScheduled(scheduled);
+    });
+    return () => { cancelled = true; };
+  }, [date]);
+
+  const state: PackBuilderState = useMemo(
+    () => ({ clubId: club?.id ?? null, players, date, alreadyScheduled }),
+    [club, players, date, alreadyScheduled],
+  );
+
+  const validation = validatePackForPublish(state);
+
+  const usedPlayerIds = useMemo(
+    () => new Set(players.filter((p): p is Player => p !== null).map((p) => p.id)),
+    [players],
+  );
+
+  function setPlayerAt(index: number, player: Player | null) {
+    setPlayers((prev) => {
+      const next = [...prev];
+      next[index] = player;
+      return next;
+    });
+  }
+
+  async function handlePublish() {
+    if (!validation.ok || !club) return;
+    setPublishing(true);
+    setPublishMessage(null);
+    const ids = players.map((p) => p!.id);
+    const result = await publishPack(date, club.id, ids);
+    setPublishing(false);
+    if (result.ok) {
+      setPublishMessage({ kind: "ok", text: `Pack published for ${date}` });
+      setPlayers(EMPTY_SLOTS);
+      setAlreadyScheduled(true);
+    } else {
+      setPublishMessage({ kind: "error", text: result.error ?? "Publish failed" });
+    }
+  }
+
+  return (
+    <section aria-label="Pack Builder" className="bg-gray-800 rounded-xl p-6">
+      <h2 className="text-xl font-semibold mb-4">Pack Builder</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-sm text-gray-400">Date</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-green-500"
+          />
+          {alreadyScheduled && (
+            <span className="text-xs text-amber-400">A pack is already scheduled for this date.</span>
+          )}
+        </label>
+
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm text-gray-400" htmlFor="club-search">Club</label>
+          {club ? (
+            <div className="flex items-center gap-2 bg-gray-700 border border-gray-600 rounded-lg px-3 py-2">
+              {club.badge && <img src={club.badge} alt="" className="w-6 h-6 object-contain" />}
+              <span className="flex-1 text-white">{club.name}</span>
+              <button
+                type="button"
+                onClick={() => { setClub(null); setClubQuery(""); }}
+                className="text-gray-400 hover:text-white text-sm"
+              >
+                Change
+              </button>
+            </div>
+          ) : (
+            <div className="relative">
+              <input
+                id="club-search"
+                type="text"
+                value={clubQuery}
+                onChange={(e) => setClubQuery(e.target.value)}
+                placeholder="Search clubs..."
+                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:border-green-500"
+              />
+              {clubResults.length > 0 && (
+                <ul role="listbox" className="absolute z-10 mt-1 w-full bg-gray-700 border border-gray-600 rounded-lg max-h-64 overflow-y-auto shadow-lg">
+                  {clubResults.map((c) => (
+                    <li key={c.id}>
+                      <button
+                        type="button"
+                        onClick={() => { setClub(c); setClubQuery(""); setClubResults([]); }}
+                        className="w-full px-3 py-2 flex items-center gap-2 hover:bg-gray-600 text-left"
+                      >
+                        {c.badge && <img src={c.badge} alt="" className="w-6 h-6 object-contain" />}
+                        <span className="text-white">{c.name}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2 mb-6">
+        <h3 className="text-sm text-gray-400">Players ({players.filter(Boolean).length} / {PACK_SIZE})</h3>
+        {players.map((player, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <span className="w-6 text-gray-500 text-sm shrink-0">{i + 1}.</span>
+            {player ? (
+              <div className="flex-1 flex items-center gap-2 bg-gray-700 border border-gray-600 rounded-lg px-3 py-2">
+                {player.thumbnail
+                  ? <img src={player.thumbnail} alt="" className="w-8 h-8 rounded-full object-cover bg-gray-600" />
+                  : <span className="w-8 h-8 rounded-full bg-red-900/50 flex items-center justify-center text-red-300 text-xs">!</span>
+                }
+                <span className="flex-1 text-white">{player.name}</span>
+                {!player.thumbnail && <span className="text-xs text-red-400">no photo</span>}
+                <button
+                  type="button"
+                  onClick={() => setPlayerAt(i, null)}
+                  className="text-gray-400 hover:text-white text-sm"
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <div className="flex-1">
+                <PlayerSearch
+                  onSelect={(p) => setPlayerAt(i, p)}
+                  usedPlayerIds={usedPlayerIds}
+                  placeholder={`Player ${i + 1}`}
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handlePublish}
+          disabled={!validation.ok || publishing}
+          className={`px-5 py-2.5 rounded-lg font-semibold transition-colors ${
+            validation.ok && !publishing
+              ? "bg-green-600 hover:bg-green-500 text-white"
+              : "bg-gray-700 text-gray-400 cursor-not-allowed"
+          }`}
+        >
+          {publishing ? "Publishing..." : "Publish Pack"}
+        </button>
+        {!validation.ok && (
+          <span className="text-sm text-gray-400">{validation.reason}</span>
+        )}
+        {publishMessage && (
+          <span
+            role="status"
+            className={`text-sm ${publishMessage.kind === "ok" ? "text-green-400" : "text-red-400"}`}
+          >
+            {publishMessage.text}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Admin/PackBuilder.tsx
+++ b/src/pages/Admin/PackBuilder.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import PlayerSearch from "../../components/PlayerSearch";
 import { searchClubs } from "../../api/adminApi";
-import { isPackScheduled, publishPack } from "../../api/packAdminApi";
+import { isPackScheduled, publishPack, getClubCandidatePool } from "../../api/packAdminApi";
 import { validatePackForPublish, type PackBuilderState } from "./packBuilderValidation";
+import { rankClubCandidates, type RankedCandidate } from "./packCandidateRanker";
+import { SEED_PLAYERS } from "../../data/seedPlayers";
 import type { Player } from "../../types";
 
 const PACK_SIZE = 10;
-const EMPTY_SLOTS: (Player | null)[] = Array(PACK_SIZE).fill(null);
+const CANDIDATE_LIMIT = 30;
+const SEED_PLAYER_IDS = new Set(SEED_PLAYERS.map((p) => p.id));
 
 interface ClubOption {
   id: string;
@@ -20,17 +22,28 @@ function getDefaultDate(): string {
   return d.toISOString().slice(0, 10);
 }
 
+function candidateAsPlayer(c: RankedCandidate): Player {
+  return {
+    id: c.id,
+    name: c.name,
+    thumbnail: c.thumbnail,
+    nationality: "",
+  };
+}
+
 export default function PackBuilder() {
   const [club, setClub] = useState<ClubOption | null>(null);
   const [clubQuery, setClubQuery] = useState("");
   const [clubResults, setClubResults] = useState<ClubOption[]>([]);
-  const [players, setPlayers] = useState<(Player | null)[]>(EMPTY_SLOTS);
+  const [candidates, setCandidates] = useState<RankedCandidate[]>([]);
+  const [loadingCandidates, setLoadingCandidates] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [date, setDate] = useState<string>(getDefaultDate);
   const [alreadyScheduled, setAlreadyScheduled] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [publishMessage, setPublishMessage] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
 
-  // Search clubs
+  // Search clubs.
   useEffect(() => {
     if (clubQuery.trim().length < 2) {
       setClubResults([]);
@@ -43,7 +56,25 @@ export default function PackBuilder() {
     return () => clearTimeout(handle);
   }, [clubQuery]);
 
-  // Check date conflict
+  // Load candidates when a club is picked.
+  useEffect(() => {
+    let cancelled = false;
+    if (!club) {
+      setCandidates([]);
+      setSelectedIds([]);
+      return;
+    }
+    setLoadingCandidates(true);
+    getClubCandidatePool(club.id).then((pool) => {
+      if (cancelled) return;
+      const ranked = rankClubCandidates(pool, SEED_PLAYER_IDS, { limit: CANDIDATE_LIMIT });
+      setCandidates(ranked);
+      setLoadingCandidates(false);
+    });
+    return () => { cancelled = true; };
+  }, [club]);
+
+  // Check date conflict.
   useEffect(() => {
     let cancelled = false;
     if (!date) {
@@ -56,36 +87,46 @@ export default function PackBuilder() {
     return () => { cancelled = true; };
   }, [date]);
 
-  const state: PackBuilderState = useMemo(
-    () => ({ clubId: club?.id ?? null, players, date, alreadyScheduled }),
-    [club, players, date, alreadyScheduled],
+  const candidateById = useMemo(
+    () => new Map(candidates.map((c) => [c.id, c])),
+    [candidates],
   );
 
-  const validation = validatePackForPublish(state);
-
-  const usedPlayerIds = useMemo(
-    () => new Set(players.filter((p): p is Player => p !== null).map((p) => p.id)),
-    [players],
+  const selectedPlayers = useMemo(
+    () => selectedIds.map((id) => candidateById.get(id)).filter((c): c is RankedCandidate => !!c),
+    [selectedIds, candidateById],
   );
 
-  function setPlayerAt(index: number, player: Player | null) {
-    setPlayers((prev) => {
-      const next = [...prev];
-      next[index] = player;
-      return next;
+  const validation = validatePackForPublish({
+    clubId: club?.id ?? null,
+    players: [
+      ...selectedPlayers.map(candidateAsPlayer),
+      ...Array(Math.max(0, PACK_SIZE - selectedPlayers.length)).fill(null),
+    ],
+    date,
+    alreadyScheduled,
+  } as PackBuilderState);
+
+  function addCandidate(id: string) {
+    setSelectedIds((prev) => {
+      if (prev.includes(id) || prev.length >= PACK_SIZE) return prev;
+      return [...prev, id];
     });
+  }
+
+  function removeSelected(id: string) {
+    setSelectedIds((prev) => prev.filter((x) => x !== id));
   }
 
   async function handlePublish() {
     if (!validation.ok || !club) return;
     setPublishing(true);
     setPublishMessage(null);
-    const ids = players.map((p) => p!.id);
-    const result = await publishPack(date, club.id, ids);
+    const result = await publishPack(date, club.id, selectedIds);
     setPublishing(false);
     if (result.ok) {
       setPublishMessage({ kind: "ok", text: `Pack published for ${date}` });
-      setPlayers(EMPTY_SLOTS);
+      setSelectedIds([]);
       setAlreadyScheduled(true);
     } else {
       setPublishMessage({ kind: "error", text: result.error ?? "Publish failed" });
@@ -155,39 +196,96 @@ export default function PackBuilder() {
         </div>
       </div>
 
-      <div className="space-y-2 mb-6">
-        <h3 className="text-sm text-gray-400">Players ({players.filter(Boolean).length} / {PACK_SIZE})</h3>
-        {players.map((player, i) => (
-          <div key={i} className="flex items-center gap-3">
-            <span className="w-6 text-gray-500 text-sm shrink-0">{i + 1}.</span>
-            {player ? (
-              <div className="flex-1 flex items-center gap-2 bg-gray-700 border border-gray-600 rounded-lg px-3 py-2">
-                {player.thumbnail
-                  ? <img src={player.thumbnail} alt="" className="w-8 h-8 rounded-full object-cover bg-gray-600" />
-                  : <span className="w-8 h-8 rounded-full bg-red-900/50 flex items-center justify-center text-red-300 text-xs">!</span>
-                }
-                <span className="flex-1 text-white">{player.name}</span>
-                {!player.thumbnail && <span className="text-xs text-red-400">no photo</span>}
-                <button
-                  type="button"
-                  onClick={() => setPlayerAt(i, null)}
-                  className="text-gray-400 hover:text-white text-sm"
-                >
-                  Remove
-                </button>
-              </div>
+      {club && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          {/* Candidate pool */}
+          <div aria-label="Candidates" className="bg-gray-900 border border-gray-700 rounded-lg p-3">
+            <h3 className="text-sm font-semibold text-gray-300 mb-2 flex items-center justify-between">
+              <span>Candidates</span>
+              <span className="text-xs text-gray-500">{candidates.length} ranked</span>
+            </h3>
+            {loadingCandidates ? (
+              <p className="text-gray-500 text-sm">Loading candidates...</p>
+            ) : candidates.length === 0 ? (
+              <p className="text-gray-500 text-sm">No eligible candidates for this club.</p>
             ) : (
-              <div className="flex-1">
-                <PlayerSearch
-                  onSelect={(p) => setPlayerAt(i, p)}
-                  usedPlayerIds={usedPlayerIds}
-                  placeholder={`Player ${i + 1}`}
-                />
-              </div>
+              <ul className="space-y-1 max-h-[36rem] overflow-y-auto">
+                {candidates.map((c) => {
+                  const isSelected = selectedIds.includes(c.id);
+                  const atCapacity = selectedIds.length >= PACK_SIZE;
+                  return (
+                    <li
+                      key={c.id}
+                      className={`flex items-center gap-2 px-2 py-1.5 rounded ${
+                        isSelected ? "bg-green-900/30 opacity-50" : "hover:bg-gray-800"
+                      }`}
+                    >
+                      <img src={c.thumbnail} alt="" className="w-8 h-8 rounded-full object-cover bg-gray-700 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-white truncate">{c.name}</div>
+                        <div className="text-xs text-gray-500 flex items-center gap-2">
+                          <span>{c.tenureLabel || "—"}</span>
+                          {c.inSeedList && <span className="text-yellow-500">★ seed</span>}
+                          {c.hasTopLeagueElsewhere && <span className="text-blue-400">top-5</span>}
+                          {c.isLoan && <span className="text-amber-400">loan</span>}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => addCandidate(c.id)}
+                        disabled={isSelected || atCapacity}
+                        aria-label={`Add ${c.name}`}
+                        className={`px-2 py-1 text-xs rounded transition-colors ${
+                          isSelected || atCapacity
+                            ? "bg-gray-700 text-gray-500 cursor-not-allowed"
+                            : "bg-green-700 hover:bg-green-600 text-white"
+                        }`}
+                      >
+                        {isSelected ? "Added" : "Add"}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
             )}
           </div>
-        ))}
-      </div>
+
+          {/* Selected 10 */}
+          <div aria-label="Selected" className="bg-gray-900 border border-gray-700 rounded-lg p-3">
+            <h3 className="text-sm font-semibold text-gray-300 mb-2 flex items-center justify-between">
+              <span>Selected</span>
+              <span className="text-xs text-gray-500">{selectedIds.length} / {PACK_SIZE}</span>
+            </h3>
+            <ul className="space-y-1">
+              {Array.from({ length: PACK_SIZE }, (_, i) => {
+                const id = selectedIds[i];
+                const player = id ? candidateById.get(id) : undefined;
+                return (
+                  <li key={i} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/50">
+                    <span className="w-5 text-xs text-gray-500 text-right shrink-0">{i + 1}.</span>
+                    {player ? (
+                      <>
+                        <img src={player.thumbnail} alt="" className="w-7 h-7 rounded-full object-cover bg-gray-700 shrink-0" />
+                        <span className="flex-1 text-sm text-white truncate">{player.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeSelected(player.id)}
+                          aria-label={`Remove ${player.name}`}
+                          className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-red-700 text-white transition-colors"
+                        >
+                          Remove
+                        </button>
+                      </>
+                    ) : (
+                      <span className="flex-1 text-sm text-gray-600 italic">empty slot</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+      )}
 
       <div className="flex items-center gap-3">
         <button

--- a/src/pages/Admin/index.tsx
+++ b/src/pages/Admin/index.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useAdminAuth } from "../../api/useAdminAuth";
 import ScheduleManager from "./ScheduleManager";
+import PackBuilder from "./PackBuilder";
+
+type AdminTab = "schedule" | "pack";
 
 function SignInForm({ onSignIn, error }: { onSignIn: (email: string, password: string) => void; error: string | null }) {
   const [email, setEmail] = useState("");
@@ -45,6 +48,7 @@ function SignInForm({ onSignIn, error }: { onSignIn: (email: string, password: s
 
 export default function Admin() {
   const { session, loading, error, signIn, signOut } = useAdminAuth();
+  const [tab, setTab] = useState<AdminTab>("schedule");
 
   if (loading) {
     return (
@@ -73,7 +77,35 @@ export default function Admin() {
             </Link>
           </div>
         </div>
-        <ScheduleManager />
+        <nav role="tablist" aria-label="Admin sections" className="flex gap-2 border-b border-gray-700 mb-6">
+          <button
+            role="tab"
+            aria-selected={tab === "schedule"}
+            onClick={() => setTab("schedule")}
+            className={`px-4 py-2 -mb-px border-b-2 transition-colors ${
+              tab === "schedule"
+                ? "border-green-500 text-white"
+                : "border-transparent text-gray-400 hover:text-white"
+            }`}
+          >
+            Schedule
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === "pack"}
+            onClick={() => setTab("pack")}
+            className={`px-4 py-2 -mb-px border-b-2 transition-colors ${
+              tab === "pack"
+                ? "border-green-500 text-white"
+                : "border-transparent text-gray-400 hover:text-white"
+            }`}
+          >
+            Pack Builder
+          </button>
+        </nav>
+
+        {tab === "schedule" && <ScheduleManager />}
+        {tab === "pack" && <PackBuilder />}
       </div>
     </div>
   );

--- a/src/pages/Admin/packBuilderValidation.ts
+++ b/src/pages/Admin/packBuilderValidation.ts
@@ -1,0 +1,35 @@
+import type { Player } from "../../types";
+
+export interface PackBuilderState {
+  clubId: string | null;
+  players: (Player | null)[];
+  date: string;
+  alreadyScheduled: boolean;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+const PACK_SIZE = 10;
+
+export function validatePackForPublish(state: PackBuilderState): ValidationResult {
+  if (!state.clubId) return { ok: false, reason: "Pick a club" };
+  if (!state.date) return { ok: false, reason: "Pick a date" };
+
+  const todayStr = new Date().toISOString().slice(0, 10);
+  if (state.date < todayStr) return { ok: false, reason: "Date must be today or future" };
+  if (state.alreadyScheduled) return { ok: false, reason: "A pack is already scheduled for this date" };
+
+  const filled = state.players.filter((p): p is Player => p !== null);
+  if (filled.length !== PACK_SIZE) return { ok: false, reason: `Need ${PACK_SIZE} players (${filled.length} selected)` };
+
+  const ids = new Set(filled.map((p) => p.id));
+  if (ids.size !== PACK_SIZE) return { ok: false, reason: "Duplicate players" };
+
+  const missingThumb = filled.find((p) => !p.thumbnail);
+  if (missingThumb) return { ok: false, reason: `${missingThumb.name} has no photo` };
+
+  return { ok: true };
+}

--- a/src/pages/Admin/packCandidateRanker.ts
+++ b/src/pages/Admin/packCandidateRanker.ts
@@ -1,0 +1,119 @@
+export interface CandidateStint {
+  yearJoined: string;
+  yearDeparted: string;
+  isLoan: boolean;
+  isYouth: boolean;
+}
+
+export interface CandidateInput {
+  id: string;
+  name: string;
+  thumbnail: string;
+  stints: CandidateStint[];
+  hasTopLeagueElsewhere: boolean;
+}
+
+export interface RankedCandidate {
+  id: string;
+  name: string;
+  thumbnail: string;
+  tenure: number;
+  tenureLabel: string;
+  isLoan: boolean;
+  hasTopLeagueElsewhere: boolean;
+  inSeedList: boolean;
+  score: number;
+}
+
+interface RankerOptions {
+  limit?: number;
+  tenureWeight?: number;
+  seedBonus?: number;
+  topLeagueBonus?: number;
+  loanPenalty?: number;
+}
+
+const DEFAULTS = {
+  tenureWeight: 1,
+  seedBonus: 5,
+  topLeagueBonus: 3,
+  loanPenalty: -2,
+};
+
+function parseYear(s: string): number | null {
+  const n = parseInt((s ?? "").trim(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function tenureFromStints(stints: CandidateStint[]): number {
+  let total = 0;
+  for (const s of stints) {
+    if (s.isYouth) continue;
+    const j = parseYear(s.yearJoined);
+    const d = parseYear(s.yearDeparted) ?? new Date().getFullYear();
+    if (j === null) continue;
+    total += Math.max(0, d - j);
+  }
+  return total;
+}
+
+function tenureLabel(stints: CandidateStint[]): string {
+  const firstJoin = stints
+    .filter((s) => !s.isYouth)
+    .map((s) => parseYear(s.yearJoined))
+    .filter((y): y is number => y !== null)
+    .reduce((a, b) => Math.min(a, b), Infinity);
+
+  const nonYouth = stints.filter((s) => !s.isYouth);
+  const anyOngoing = nonYouth.some((s) => !parseYear(s.yearDeparted));
+
+  if (!Number.isFinite(firstJoin)) return "";
+  if (anyOngoing) return `${firstJoin}–present`;
+
+  const lastDepart = nonYouth
+    .map((s) => parseYear(s.yearDeparted))
+    .filter((y): y is number => y !== null)
+    .reduce((a, b) => Math.max(a, b), -Infinity);
+
+  return Number.isFinite(lastDepart) ? `${firstJoin}–${lastDepart}` : `${firstJoin}`;
+}
+
+export function rankClubCandidates(
+  inputs: CandidateInput[],
+  seedPlayerIds: Set<string>,
+  options: RankerOptions = {},
+): RankedCandidate[] {
+  const opts = { ...DEFAULTS, ...options };
+  const ranked: RankedCandidate[] = [];
+
+  for (const c of inputs) {
+    if (!c.thumbnail) continue;
+    const nonYouth = c.stints.filter((s) => !s.isYouth);
+    if (nonYouth.length === 0) continue;
+
+    const tenure = tenureFromStints(c.stints);
+    const isLoan = nonYouth.some((s) => s.isLoan);
+    const inSeedList = seedPlayerIds.has(c.id);
+
+    const score =
+      tenure * opts.tenureWeight +
+      (inSeedList ? opts.seedBonus : 0) +
+      (c.hasTopLeagueElsewhere ? opts.topLeagueBonus : 0) +
+      (isLoan ? opts.loanPenalty : 0);
+
+    ranked.push({
+      id: c.id,
+      name: c.name,
+      thumbnail: c.thumbnail,
+      tenure,
+      tenureLabel: tenureLabel(c.stints),
+      isLoan,
+      hasTopLeagueElsewhere: c.hasTopLeagueElsewhere,
+      inSeedList,
+      score,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+  return options.limit ? ranked.slice(0, options.limit) : ranked;
+}


### PR DESCRIPTION
## Summary
Bundles slice 08 (admin publish form) and slice 09 (heuristic candidate panel) — #57 merged into its parent feature branch but never reached main, so retargeting this PR's base to \`main\` collapses both slices into one cumulative diff.

### Slice 08 — admin publish form
- New "Pack Builder" tab in \`/admin\` alongside the existing Schedule manager
- Pure \`validatePackForPublish\` enforces: club picked, future date, no existing schedule, exactly 10 unique players, every player has a thumbnail
- \`isPackScheduled(date)\` checks the date conflict; \`publishPack(date, clubId, ids)\` performs the insert
- RLS on \`pack_schedule\` already restricts writes to \`is_admin()\` from migration 012

### Slice 09 — heuristic candidate panel
- Pure \`rankClubCandidates(inputs, seedIds, options?)\` scores: \`tenure × 1 + (inSeed ? 5 : 0) + (topLeagueElsewhere ? 3 : 0) − (anyLoan ? 2 : 0)\`
- Excludes players whose only stints are youth or who have no thumbnail
- New \`getClubCandidatePool(clubId)\` fetches \`player_clubs\` for the club + a second query to flag top-5-league careers
- UI: two-panel layout — ~30 ranked candidates on the left, 10-slot Selected panel on the right; Add/Remove moves players between
- Each candidate row shows thumbnail, name, tenure label, and badges for ★ seed / top-5 / loan

## Test plan
- [ ] \`npm test\` — 18 new unit tests (8 validator + 10 ranker)
- [ ] \`PACK_ADMIN_EMAIL=… PACK_ADMIN_PASSWORD=… npm run test:e2e -- e2e/pack-admin.spec.ts\` — sign in, pick club, candidates rank, add 10, publish (mocked insert)
- [ ] Manual: sign in to /admin → Pack Builder tab → pick a club → candidate list ranks → Add 10 → Publish; visit /pack on that date → pack plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)