### PR TITLE
feat: drag + button reorder for pack admin (slice 10)

### DIFF
--- a/e2e/pack-admin.spec.ts
+++ b/e2e/pack-admin.spec.ts
@@ -97,4 +97,57 @@ test.describe("Admin Pack Builder", () => {
     await publishBtn.click();
     await expect(builder.getByRole("status")).toContainText(/Pack published/);
   });
+
+  test("selected players can be reordered with the up/down controls", async ({ page }) => {
+    if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+      test.skip(true, "Set PACK_ADMIN_EMAIL/PACK_ADMIN_PASSWORD to run admin e2e.");
+      return;
+    }
+
+    await page.route(/\/rest\/v1\/pack_schedule(\?.*)?$/, (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto("/#/admin");
+    await page.getByPlaceholder("Email").fill(ADMIN_EMAIL);
+    await page.getByPlaceholder("Password").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await page.getByRole("tab", { name: "Pack Builder" }).click();
+    const builder = page.getByLabel("Pack Builder");
+
+    await builder.getByPlaceholder("Search clubs...").fill("Liverpool");
+    const clubOption = page.getByRole("listbox").getByRole("button").first();
+    await clubOption.waitFor({ state: "visible", timeout: 5_000 });
+    await clubOption.click();
+
+    const candidatesPanel = builder.getByLabel("Candidates");
+    await candidatesPanel.getByRole("button", { name: /^Add / }).first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Add at least 3 candidates so we can reorder.
+    for (let i = 0; i < 3; i++) {
+      const enabledAdd = candidatesPanel.getByRole("button", { name: /^Add / }).filter({ hasNotText: "Added" }).first();
+      const ok = await enabledAdd.waitFor({ state: "visible", timeout: 3_000 }).then(() => true).catch(() => false);
+      if (!ok) break;
+      await enabledAdd.click();
+    }
+
+    const selectedPanel = builder.getByLabel("Selected");
+    const slot1Name = (await selectedPanel.locator("li").nth(0).locator("img + span").textContent())?.trim();
+    const slot2Name = (await selectedPanel.locator("li").nth(1).locator("img + span").textContent())?.trim();
+    if (!slot1Name || !slot2Name) {
+      test.skip(true, "Could not read names from the first two selected slots.");
+      return;
+    }
+
+    // Move slot 1's player down — they should swap places with slot 2's player.
+    await selectedPanel.getByRole("button", { name: `Move ${slot1Name} down` }).click();
+
+    await expect(selectedPanel.locator("li").nth(0).locator("img + span")).toHaveText(slot2Name);
+    await expect(selectedPanel.locator("li").nth(1).locator("img + span")).toHaveText(slot1Name);
+  });
 });

--- a/src/__tests__/packReorder.test.ts
+++ b/src/__tests__/packReorder.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { reorder } from "../pages/Admin/packReorder";
+
+describe("reorder", () => {
+  it("moves an item to a later index", () => {
+    expect(reorder(["a", "b", "c", "d"], 0, 2)).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves an item to an earlier index", () => {
+    expect(reorder(["a", "b", "c", "d"], 3, 1)).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("returns the original array reference when from === to", () => {
+    const arr = ["a", "b", "c"];
+    expect(reorder(arr, 1, 1)).toBe(arr);
+  });
+
+  it("returns the original array when indices are out of bounds", () => {
+    const arr = ["a", "b", "c"];
+    expect(reorder(arr, -1, 0)).toBe(arr);
+    expect(reorder(arr, 0, 5)).toBe(arr);
+  });
+
+  it("does not mutate the input", () => {
+    const arr = ["a", "b", "c"];
+    reorder(arr, 0, 2);
+    expect(arr).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/pages/Admin/PackBuilder.tsx
+++ b/src/pages/Admin/PackBuilder.tsx
@@ -3,6 +3,7 @@ import { searchClubs } from "../../api/adminApi";
 import { isPackScheduled, publishPack, getClubCandidatePool } from "../../api/packAdminApi";
 import { validatePackForPublish, type PackBuilderState } from "./packBuilderValidation";
 import { rankClubCandidates, type RankedCandidate } from "./packCandidateRanker";
+import { reorder } from "./packReorder";
 import { SEED_PLAYERS } from "../../data/seedPlayers";
 import type { Player } from "../../types";
 
@@ -116,6 +117,31 @@ export default function PackBuilder() {
 
   function removeSelected(id: string) {
     setSelectedIds((prev) => prev.filter((x) => x !== id));
+  }
+
+  function moveSelected(from: number, to: number) {
+    setSelectedIds((prev) => reorder(prev, from, to));
+  }
+
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
+  function handleDragStart(index: number) {
+    setDraggingIndex(index);
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+  }
+
+  function handleDrop(e: React.DragEvent, index: number) {
+    e.preventDefault();
+    if (draggingIndex === null) return;
+    moveSelected(draggingIndex, index);
+    setDraggingIndex(null);
+  }
+
+  function handleDragEnd() {
+    setDraggingIndex(null);
   }
 
   async function handlePublish() {
@@ -256,25 +282,59 @@ export default function PackBuilder() {
               <span>Selected</span>
               <span className="text-xs text-gray-500">{selectedIds.length} / {PACK_SIZE}</span>
             </h3>
+            <p className="text-xs text-gray-500 mb-2">1 = easiest · {PACK_SIZE} = hardest. Drag to reorder.</p>
             <ul className="space-y-1">
               {Array.from({ length: PACK_SIZE }, (_, i) => {
                 const id = selectedIds[i];
                 const player = id ? candidateById.get(id) : undefined;
+                const filled = !!player;
+                const isDragging = draggingIndex === i;
                 return (
-                  <li key={i} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/50">
+                  <li
+                    key={i}
+                    draggable={filled}
+                    onDragStart={() => filled && handleDragStart(i)}
+                    onDragOver={handleDragOver}
+                    onDrop={(e) => handleDrop(e, i)}
+                    onDragEnd={handleDragEnd}
+                    aria-label={filled ? `Selected slot ${i + 1}` : undefined}
+                    className={`flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/50 ${
+                      filled ? "cursor-grab active:cursor-grabbing" : ""
+                    } ${isDragging ? "opacity-50" : ""}`}
+                  >
                     <span className="w-5 text-xs text-gray-500 text-right shrink-0">{i + 1}.</span>
                     {player ? (
                       <>
                         <img src={player.thumbnail} alt="" className="w-7 h-7 rounded-full object-cover bg-gray-700 shrink-0" />
                         <span className="flex-1 text-sm text-white truncate">{player.name}</span>
-                        <button
-                          type="button"
-                          onClick={() => removeSelected(player.id)}
-                          aria-label={`Remove ${player.name}`}
-                          className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-red-700 text-white transition-colors"
-                        >
-                          Remove
-                        </button>
+                        <div className="flex items-center gap-1 shrink-0">
+                          <button
+                            type="button"
+                            onClick={() => moveSelected(i, i - 1)}
+                            disabled={i === 0}
+                            aria-label={`Move ${player.name} up`}
+                            className="px-1.5 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-30 disabled:cursor-not-allowed text-white transition-colors"
+                          >
+                            ↑
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => moveSelected(i, i + 1)}
+                            disabled={i >= selectedIds.length - 1}
+                            aria-label={`Move ${player.name} down`}
+                            className="px-1.5 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-30 disabled:cursor-not-allowed text-white transition-colors"
+                          >
+                            ↓
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => removeSelected(player.id)}
+                            aria-label={`Remove ${player.name}`}
+                            className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-red-700 text-white transition-colors"
+                          >
+                            Remove
+                          </button>
+                        </div>
                       </>
                     ) : (
                       <span className="flex-1 text-sm text-gray-600 italic">empty slot</span>

--- a/src/pages/Admin/packReorder.ts
+++ b/src/pages/Admin/packReorder.ts
@@ -1,0 +1,9 @@
+export function reorder<T>(items: T[], from: number, to: number): T[] {
+  if (from === to) return items;
+  if (from < 0 || from >= items.length) return items;
+  if (to < 0 || to >= items.length) return items;
+  const next = [...items];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}


### PR DESCRIPTION
## Summary
- Selected-10 panel supports HTML5 drag-and-drop on desktop pointers and up/down buttons everywhere (touch-friendly, accessible)
- Pure \`reorder<T>(items, from, to)\` helper does the array math
- Position numbers (1 = easiest, 10 = hardest) update live as items move; a hint label spells out the difficulty curve
- Published pack respects post-reorder order (publishPack already takes selectedIds in their current order)

Stacks on PR #58 (slices 08 + 09 / admin form + candidate panel). Per \`.scratch/pack-mode/issues/10-admin-drag-reorder.md\`.

## Test plan
- [ ] \`npm test\` — 5 new unit tests on the pure \`reorder\` helper
- [ ] \`PACK_ADMIN_EMAIL=… PACK_ADMIN_PASSWORD=… npm run test:e2e -- e2e/pack-admin.spec.ts\` — adds 3 candidates, clicks "Move down" on slot 1, asserts swap with slot 2
- [ ] Manual: build a pack, drag slot 1 to slot 5 — order updates; click ↑/↓ on a touch device — order updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)