### PR TITLE
feat: edit published packs in admin builder

### DIFF
--- a/src/__tests__/packBuilderValidation.test.ts
+++ b/src/__tests__/packBuilderValidation.test.ts
@@ -104,4 +104,26 @@ describe("validatePackForPublish", () => {
     expect(r.ok).toBe(true);
     expect(r.reason).toBeUndefined();
   });
+
+  it("allows editing an existing scheduled pack on the same date", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: FUTURE_DATE,
+      alreadyScheduled: true,
+      isEditingExisting: true,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("allows editing a pack on a past date (e.g. fixing yesterday's pack)", () => {
+    const r = validatePackForPublish({
+      clubId: "club-1",
+      players: tenPlayers(),
+      date: "2000-01-01",
+      alreadyScheduled: true,
+      isEditingExisting: true,
+    });
+    expect(r.ok).toBe(true);
+  });
 });

--- a/src/api/packAdminApi.ts
+++ b/src/api/packAdminApi.ts
@@ -20,6 +20,56 @@ export async function isPackScheduled(date: string): Promise<boolean> {
   return !error && !!data;
 }
 
+export interface AdminPackPlayer {
+  id: string;
+  name: string;
+  thumbnail: string;
+}
+
+export interface AdminPack {
+  date: string;
+  club: { id: string; name: string; badge: string };
+  players: AdminPackPlayer[];
+}
+
+interface AdminPackRow {
+  date: string;
+  club_id: string;
+  player_ids: string[];
+  clubs: { id: string; name: string; badge: string } | null;
+}
+
+export async function getPackForAdmin(date: string): Promise<AdminPack | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from("pack_schedule")
+    .select("date, club_id, player_ids, clubs(id, name, badge)")
+    .eq("date", date)
+    .maybeSingle();
+  if (error || !data) return null;
+  const row = data as unknown as AdminPackRow;
+  if (!row.clubs) return null;
+
+  const { data: playerRows } = await supabase
+    .from("players")
+    .select("id, name, thumbnail")
+    .in("id", row.player_ids);
+
+  const byId = new Map<string, AdminPackPlayer>();
+  for (const p of (playerRows ?? []) as AdminPackPlayer[]) {
+    byId.set(p.id, { id: p.id, name: p.name, thumbnail: p.thumbnail ?? "" });
+  }
+  const players = row.player_ids
+    .map((id) => byId.get(id))
+    .filter((p): p is AdminPackPlayer => !!p);
+
+  return {
+    date: row.date,
+    club: { id: row.clubs.id, name: row.clubs.name, badge: row.clubs.badge },
+    players,
+  };
+}
+
 export interface PublishPackResult {
   ok: boolean;
   error?: string;
@@ -37,6 +87,24 @@ export async function publishPack(
   const { error } = await supabase
     .from("pack_schedule")
     .insert({ date, club_id: clubId, player_ids: playerIds });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}
+
+export async function updatePack(
+  date: string,
+  clubId: string,
+  playerIds: string[],
+): Promise<PublishPackResult> {
+  if (!supabase) return { ok: false, error: "Supabase unavailable" };
+  if (playerIds.length !== 10) return { ok: false, error: "Pack must have exactly 10 players" };
+  if (new Set(playerIds).size !== 10) return { ok: false, error: "Player list contains duplicates" };
+
+  const { error } = await supabase
+    .from("pack_schedule")
+    .update({ club_id: clubId, player_ids: playerIds })
+    .eq("date", date);
 
   if (error) return { ok: false, error: error.message };
   return { ok: true };

--- a/src/pages/Admin/PackBuilder.tsx
+++ b/src/pages/Admin/PackBuilder.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { searchClubs } from "../../api/adminApi";
-import { isPackScheduled, publishPack, getClubCandidatePool } from "../../api/packAdminApi";
+import { getPackForAdmin, publishPack, updatePack, getClubCandidatePool } from "../../api/packAdminApi";
 import { validatePackForPublish, type PackBuilderState } from "./packBuilderValidation";
 import { rankClubCandidates, type RankedCandidate } from "./packCandidateRanker";
 import { reorder } from "./packReorder";
@@ -40,8 +40,10 @@ export default function PackBuilder() {
   const [loadingCandidates, setLoadingCandidates] = useState(false);
   const [candidateQuery, setCandidateQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [extraPlayersById, setExtraPlayersById] = useState<Map<string, RankedCandidate>>(new Map());
   const [date, setDate] = useState<string>(getDefaultDate);
-  const [alreadyScheduled, setAlreadyScheduled] = useState(false);
+  const [editingExisting, setEditingExisting] = useState(false);
+  const [loadingPack, setLoadingPack] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [publishMessage, setPublishMessage] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
 
@@ -78,23 +80,52 @@ export default function PackBuilder() {
     return () => { cancelled = true; };
   }, [club]);
 
-  // Check date conflict.
+  // Load existing pack for the chosen date (edit mode) or reset to create mode.
   useEffect(() => {
     let cancelled = false;
     if (!date) {
-      setAlreadyScheduled(false);
+      setEditingExisting(false);
       return;
     }
-    isPackScheduled(date).then((scheduled) => {
-      if (!cancelled) setAlreadyScheduled(scheduled);
+    setLoadingPack(true);
+    getPackForAdmin(date).then((existing) => {
+      if (cancelled) return;
+      setLoadingPack(false);
+      if (existing) {
+        setEditingExisting(true);
+        setClub(existing.club);
+        setSelectedIds(existing.players.map((p) => p.id));
+        const map = new Map<string, RankedCandidate>();
+        for (const p of existing.players) {
+          map.set(p.id, {
+            id: p.id,
+            name: p.name,
+            thumbnail: p.thumbnail,
+            tenure: 0,
+            tenureLabel: "",
+            isLoan: false,
+            hasTopLeagueElsewhere: false,
+            inSeedList: false,
+            score: 0,
+          });
+        }
+        setExtraPlayersById(map);
+        setPublishMessage(null);
+      } else {
+        setEditingExisting(false);
+        setExtraPlayersById(new Map());
+      }
     });
     return () => { cancelled = true; };
   }, [date]);
 
-  const candidateById = useMemo(
-    () => new Map(candidates.map((c) => [c.id, c])),
-    [candidates],
-  );
+  const candidateById = useMemo(() => {
+    const m = new Map<string, RankedCandidate>(candidates.map((c) => [c.id, c]));
+    for (const [id, p] of extraPlayersById) {
+      if (!m.has(id)) m.set(id, p);
+    }
+    return m;
+  }, [candidates, extraPlayersById]);
 
   const visibleCandidates = useMemo(() => {
     const q = candidateQuery.trim().toLowerCase();
@@ -114,7 +145,8 @@ export default function PackBuilder() {
       ...Array(Math.max(0, PACK_SIZE - selectedPlayers.length)).fill(null),
     ],
     date,
-    alreadyScheduled,
+    alreadyScheduled: editingExisting,
+    isEditingExisting: editingExisting,
   } as PackBuilderState);
 
   function addCandidate(id: string) {
@@ -157,14 +189,20 @@ export default function PackBuilder() {
     if (!validation.ok || !club) return;
     setPublishing(true);
     setPublishMessage(null);
-    const result = await publishPack(date, club.id, selectedIds);
+    const result = editingExisting
+      ? await updatePack(date, club.id, selectedIds)
+      : await publishPack(date, club.id, selectedIds);
     setPublishing(false);
     if (result.ok) {
-      setPublishMessage({ kind: "ok", text: `Pack published for ${date}` });
-      setSelectedIds([]);
-      setAlreadyScheduled(true);
+      if (editingExisting) {
+        setPublishMessage({ kind: "ok", text: `Pack updated for ${date}` });
+      } else {
+        setPublishMessage({ kind: "ok", text: `Pack published for ${date}` });
+        setSelectedIds([]);
+        setEditingExisting(true);
+      }
     } else {
-      setPublishMessage({ kind: "error", text: result.error ?? "Publish failed" });
+      setPublishMessage({ kind: "error", text: result.error ?? "Save failed" });
     }
   }
 
@@ -181,8 +219,11 @@ export default function PackBuilder() {
             onChange={(e) => setDate(e.target.value)}
             className="bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-green-500"
           />
-          {alreadyScheduled && (
-            <span className="text-xs text-amber-400">A pack is already scheduled for this date.</span>
+          {loadingPack && (
+            <span className="text-xs text-gray-400">Checking schedule...</span>
+          )}
+          {editingExisting && !loadingPack && (
+            <span className="text-xs text-blue-400">Editing existing pack for this date.</span>
           )}
         </label>
 
@@ -381,7 +422,9 @@ export default function PackBuilder() {
               : "bg-gray-700 text-gray-400 cursor-not-allowed"
           }`}
         >
-          {publishing ? "Publishing..." : "Publish Pack"}
+          {publishing
+            ? editingExisting ? "Saving..." : "Publishing..."
+            : editingExisting ? "Save Changes" : "Publish Pack"}
         </button>
         {!validation.ok && (
           <span className="text-sm text-gray-400">{validation.reason}</span>

--- a/src/pages/Admin/packBuilderValidation.ts
+++ b/src/pages/Admin/packBuilderValidation.ts
@@ -5,6 +5,7 @@ export interface PackBuilderState {
   players: (Player | null)[];
   date: string;
   alreadyScheduled: boolean;
+  isEditingExisting?: boolean;
 }
 
 export interface ValidationResult {
@@ -19,8 +20,8 @@ export function validatePackForPublish(state: PackBuilderState): ValidationResul
   if (!state.date) return { ok: false, reason: "Pick a date" };
 
   const todayStr = new Date().toISOString().slice(0, 10);
-  if (state.date < todayStr) return { ok: false, reason: "Date must be today or future" };
-  if (state.alreadyScheduled) return { ok: false, reason: "A pack is already scheduled for this date" };
+  if (state.date < todayStr && !state.isEditingExisting) return { ok: false, reason: "Date must be today or future" };
+  if (state.alreadyScheduled && !state.isEditingExisting) return { ok: false, reason: "A pack is already scheduled for this date" };
 
   const filled = state.players.filter((p): p is Player => p !== null);
   if (filled.length !== PACK_SIZE) return { ok: false, reason: `Need ${PACK_SIZE} players (${filled.length} selected)` };


### PR DESCRIPTION
## Summary
- Picking a date that already has a scheduled pack now auto-loads it into the builder (club + 10 players prefilled). The publish button becomes "Save Changes" and the save issues an `UPDATE` instead of an `INSERT`.
- The "already scheduled" warning is replaced with a clearer "Editing existing pack for this date" indicator.
- The past-date and already-scheduled validation guards are skipped in edit mode so admins can also amend yesterday's or today's published pack.
- Loaded pack players are added to a side lookup map so they render correctly even if they aren't in the top-30 ranked candidates list for their club.

## Notes
- DB schema unchanged — admin UPDATE policy on `pack_schedule` already exists in `012_pack_mode.sql`.
- Two new unit tests cover edit-mode validation (allows already-scheduled date, allows past date).

## Test plan
- [ ] Pick a date with no pack: builder works as before, saves with INSERT
- [ ] Pick a date with an existing pack: indicator shows "Editing existing pack...", club + players prefill, button reads "Save Changes"
- [ ] Edit a player slot, save: pack updates in DB, success message shown, form stays in edit mode
- [ ] Switch club while editing: candidate list reloads, selection clears, can rebuild and save
- [ ] Picking a past date with an existing pack still allows editing
- [ ] Switching from a pack-date to an empty date returns to create mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)