### PR TITLE
feat: pack title on gameplay page

### DIFF
--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -85,6 +85,11 @@ export default function Pack() {
               <img src={pack.club.badge} alt={pack.club.name} className="w-16 h-16 object-contain" />
             )}
 
+            <div className="text-center">
+              <h2 className="text-2xl font-bold">{pack.club.name} Pack</h2>
+              <p className="text-gray-400 text-sm">Pack #{getPackDayNumber(pack.date)}</p>
+            </div>
+
             <ProgressStrip total={pack.players.length} attempts={attempts} currentIndex={currentIndex} />
 
             <div className="text-lg">


### PR DESCRIPTION
## Summary
Adds a prominent "{Club} Pack" heading and pack number under the club crest during gameplay (playing + revealing states). Today the page only identified the pack via a small gray subtitle in the page header; this puts it front-and-center so players see what they're solving.

## Test plan
- [ ] Open today's pack — verify the heading shows "{Club Name} Pack · Pack #N" between the crest and the progress strip
- [ ] Reveal a card — heading remains visible
- [ ] Finished state still shows the existing "Club · Pack #N" line above the score (no duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)