### PR TITLE
feat: add skip button to pack mode (#67)

### DIFF
--- a/e2e/pack-hints.spec.ts
+++ b/e2e/pack-hints.spec.ts
@@ -19,7 +19,7 @@ test.describe("Pack mode hints", () => {
     // Submit a wrong guess.
     await search.fill("Wayne Rooney");
     let option = page.getByRole("option").first();
-    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.waitFor({ state: "visible", timeout: 15_000 });
     await option.click();
 
     // If that was the answer we advance — skip rest.
@@ -35,7 +35,7 @@ test.describe("Pack mode hints", () => {
     // 2nd wrong guess.
     await search.fill("Lionel Messi");
     option = page.getByRole("option").first();
-    await option.waitFor({ state: "visible", timeout: 5_000 });
+    await option.waitFor({ state: "visible", timeout: 15_000 });
     await option.click();
 
     if (await page.getByText(/Player\s+2\s*\/\s*10/).isVisible()) {

--- a/src/__tests__/packGameLogic.test.ts
+++ b/src/__tests__/packGameLogic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { initialState, submitGuess, advance } from "../pages/Pack/gameLogic";
+import { initialState, submitGuess, advance, skipPlayer } from "../pages/Pack/gameLogic";
 import type { PackData } from "../pages/Pack/types";
 import type { Player, PlayerWithTeams } from "../types";
 
@@ -130,5 +130,75 @@ describe("pack gameLogic — correct guess", () => {
     expect(next.attempts).toHaveLength(1);
     expect(next.attempts[0]).toEqual({ playerId: "p1", correct: true, guesses: 1 });
     expect(next.currentIndex).toBe(0);
+  });
+});
+
+describe("pack gameLogic — skipPlayer", () => {
+  it("transitions to 'revealing' with a failed, skipped attempt when no guesses used", () => {
+    const pack = makePack();
+    const state = initialState(pack);
+    const next = skipPlayer(state);
+
+    expect(next.status).toBe("revealing");
+    expect(next.score).toBe(0);
+    expect(next.attempts).toHaveLength(1);
+    expect(next.attempts[0]).toEqual({ playerId: "p1", correct: false, guesses: 0, skipped: true });
+  });
+
+  it("preserves guesses already used when skipping after wrong attempts", () => {
+    const pack = makePack();
+    const wrong: Player = { id: "w1", name: "Wrong", thumbnail: "", nationality: "" };
+    let state = initialState(pack);
+    state = submitGuess(state, wrong);
+    state = submitGuess(state, wrong);
+    const next = skipPlayer(state);
+
+    expect(next.status).toBe("revealing");
+    expect(next.score).toBe(0);
+    expect(next.guessesForCurrent).toBe(2);
+    expect(next.attempts[0]).toEqual({ playerId: "p1", correct: false, guesses: 2, skipped: true });
+  });
+
+  it("is ignored while revealing", () => {
+    const pack = makePack();
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    expect(state.status).toBe("revealing");
+    const after = skipPlayer(state);
+    expect(after).toBe(state);
+  });
+
+  it("is ignored when finished", () => {
+    const pack = makePack(1);
+    let state = initialState(pack);
+    state = submitGuess(state, asGuess(pack.players[0]));
+    state = advance(state);
+    expect(state.status).toBe("finished");
+    const after = skipPlayer(state);
+    expect(after).toBe(state);
+  });
+
+  it("works correctly in a full game with mixed skips and guesses", () => {
+    const pack = makePack(3);
+    let state = initialState(pack);
+
+    state = skipPlayer(state);
+    state = advance(state);
+    expect(state.currentIndex).toBe(1);
+
+    state = submitGuess(state, asGuess(pack.players[1]));
+    state = advance(state);
+    expect(state.currentIndex).toBe(2);
+
+    state = skipPlayer(state);
+    state = advance(state);
+
+    expect(state.status).toBe("finished");
+    expect(state.score).toBe(1);
+    expect(state.attempts).toEqual([
+      { playerId: "p1", correct: false, guesses: 0, skipped: true },
+      { playerId: "p2", correct: true, guesses: 1 },
+      { playerId: "p3", correct: false, guesses: 0, skipped: true },
+    ]);
   });
 });

--- a/src/pages/Pack/gameLogic.ts
+++ b/src/pages/Pack/gameLogic.ts
@@ -51,6 +51,19 @@ export function submitGuess(state: PackGameState, guess: Player): PackGameState 
   };
 }
 
+export function skipPlayer(state: PackGameState): PackGameState {
+  if (!state.pack || state.status !== "playing") return state;
+  const target = state.pack.players[state.currentIndex];
+  return {
+    ...state,
+    status: "revealing",
+    attempts: [
+      ...state.attempts,
+      { playerId: target.id, correct: false, guesses: state.guessesForCurrent, skipped: true },
+    ],
+  };
+}
+
 export function advance(state: PackGameState): PackGameState {
   if (!state.pack || state.status !== "revealing") return state;
   const nextIndex = state.currentIndex + 1;

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -114,7 +114,7 @@ export default function Pack() {
                   <p className={`text-xl font-bold ${lastAttempt?.correct ? "text-green-400" : "text-red-400"}`}>
                     {currentPlayer.name}
                   </p>
-                  <p className="text-gray-400 text-sm">{lastAttempt?.correct ? "Correct!" : lastAttempt?.skipped ? "Skipped" : "Out of guesses"}</p>
+                  <p className="text-gray-400 text-sm">{revealLabel(lastAttempt)}</p>
                 </div>
               )}
             </div>
@@ -197,6 +197,12 @@ export default function Pack() {
       </main>
     </div>
   );
+}
+
+function revealLabel(attempt: { correct: boolean; skipped?: boolean } | undefined): string {
+  if (attempt?.correct) return "Correct!";
+  if (attempt?.skipped) return "Skipped";
+  return "Out of guesses";
 }
 
 function HintsList({ hints }: { hints: ReturnType<typeof deriveHints> }) {

--- a/src/pages/Pack/index.tsx
+++ b/src/pages/Pack/index.tsx
@@ -8,7 +8,7 @@ import { buildShareText, getPackDayNumber } from "./helpers";
 import PackLeaderboard from "../../components/PackLeaderboard";
 
 export default function Pack() {
-  const { state, submitGuess, stats } = usePackGame();
+  const { state, submitGuess, skip, stats } = usePackGame();
   const { pack, status, currentIndex, guessesForCurrent, wrongGuessesForCurrent, score, attempts, error } = state;
   const currentPlayer = pack?.players[currentIndex] ?? null;
   const lastAttempt = attempts[attempts.length - 1];
@@ -114,7 +114,7 @@ export default function Pack() {
                   <p className={`text-xl font-bold ${lastAttempt?.correct ? "text-green-400" : "text-red-400"}`}>
                     {currentPlayer.name}
                   </p>
-                  <p className="text-gray-400 text-sm">{lastAttempt?.correct ? "Correct!" : "Out of guesses"}</p>
+                  <p className="text-gray-400 text-sm">{lastAttempt?.correct ? "Correct!" : lastAttempt?.skipped ? "Skipped" : "Out of guesses"}</p>
                 </div>
               )}
             </div>
@@ -122,7 +122,15 @@ export default function Pack() {
             {hints && <HintsList hints={hints} />}
 
             {status === "playing" && (
-              <PlayerSearch onSelect={submitGuess} placeholder="Player name" hideThumbnails />
+              <div className="flex flex-col items-center gap-2 max-w-sm w-full">
+                <PlayerSearch onSelect={submitGuess} placeholder="Player name" hideThumbnails />
+                <button
+                  onClick={skip}
+                  className="px-4 py-2 text-sm text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+                >
+                  Skip
+                </button>
+              </div>
             )}
 
             {wrongGuessesForCurrent.length > 0 && (

--- a/src/pages/Pack/types.ts
+++ b/src/pages/Pack/types.ts
@@ -18,6 +18,7 @@ export interface PackAttempt {
   playerId: string;
   correct: boolean;
   guesses: number;
+  skipped?: boolean;
 }
 
 export interface PackGameState {

--- a/src/pages/Pack/usePackGame.ts
+++ b/src/pages/Pack/usePackGame.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getPackForDate, getScheduledPackDatesBetween } from "../../api/packSchedule";
 import type { Player } from "../../types";
-import { initialState, submitGuess as reduceGuess, advance as reduceAdvance } from "./gameLogic";
+import { initialState, submitGuess as reduceGuess, advance as reduceAdvance, skipPlayer as reduceSkip } from "./gameLogic";
 import type { PackGameState } from "./types";
 import { getTodayString } from "../../utils/dates";
 import { loadPackResult, savePackResult } from "./helpers";
@@ -98,6 +98,10 @@ export function usePackGame() {
     setState((s) => reduceAdvance(s));
   }, []);
 
+  const skip = useCallback(() => {
+    setState((s) => reduceSkip(s));
+  }, []);
+
   useEffect(() => {
     if (state.status !== "revealing") return;
     const id = setTimeout(() => {
@@ -106,5 +110,5 @@ export function usePackGame() {
     return () => clearTimeout(id);
   }, [state.status, state.currentIndex]);
 
-  return { state, submitGuess, advance, today, stats };
+  return { state, submitGuess, advance, skip, today, stats };
 }


### PR DESCRIPTION
## Summary
- Adds a **Skip** button below the player search in Pack Mode so a player can move past one they don't recognize without burning all 3 guesses.
- `skipPlayer` is a pure reducer alongside `submitGuess`; `PackAttempt` gains an optional `skipped` flag.
- Reveal text shows "Skipped" (vs "Out of guesses" / "Correct!"). Share text + leaderboard treat skip as a miss (❌), so existing payloads are unchanged.
- Includes a small follow-up refactor to extract a `revealLabel` helper instead of a nested ternary in the reveal banner.

Closes #67.

## Test plan
- [ ] CI: 5 new unit tests in `src/__tests__/packGameLogic.test.ts` (skip records used guesses, skip ends the attempt, skip vs exhausted distinction)
- [ ] CI: typecheck + lint
- [ ] Manual: start a pack, skip a player on guess 0 / 1 / 2 — confirm "Skipped" banner and that share text shows ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Sandcastle