### PR TITLE
fix(sandcastle): publish PRs instead of merging into main

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -10,11 +10,20 @@
 //                               reviewer runs in the same sandbox on the same
 //                               branch (1 iteration). All issue pipelines run
 //                               concurrently via Promise.allSettled().
-//   Phase 3 (Merge):            A single agent merges all completed branches
-//                               into the current branch.
+//   Phase 3 (Publish):          A single agent pushes each completed branch
+//                               to origin and opens a pull request for human
+//                               review. Branches are never auto-merged into
+//                               main and issues are not auto-closed — both
+//                               happen when the human merges the PR.
 //
 // The outer loop repeats up to MAX_ITERATIONS times so that newly unblocked
-// issues are picked up after each round of merges.
+// issues are picked up after each round of publish.
+//
+// NOTE: because Phase 3 no longer merges into the current branch, the next
+// iteration's planner will keep re-picking issues whose PRs are still open.
+// That's expected — once the human merges a PR and closes its issue, the
+// planner stops selecting it. If you want to clear the queue locally without
+// waiting for the human, close the issue manually.
 //
 // Usage:
 //   npx tsx .sandcastle/main.ts
@@ -193,18 +202,19 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   }
 
   // -------------------------------------------------------------------------
-  // Phase 3: Merge
+  // Phase 3: Publish
   //
-  // One agent merges all completed branches into the current branch,
-  // resolving any conflicts and running tests to confirm everything works.
+  // One agent pushes each completed branch to origin and opens a pull
+  // request for human review. No direct merges into main, no auto-closing
+  // of issues — the human does both when they merge the PR.
   //
-  // The {{BRANCHES}} and {{ISSUES}} prompt arguments are lists that the agent
-  // uses to know which branches to merge and which issues to close.
+  // The {{BRANCHES}} and {{ISSUES}} prompt arguments tell the agent which
+  // branches to publish and which issue ID each PR should close.
   // -------------------------------------------------------------------------
   await sandcastle.run({
     hooks,
     sandbox: docker(),
-    name: "merger",
+    name: "publisher",
     maxIterations: 1,
     agent: sandcastle.claudeCode("claude-opus-4-6"),
     promptFile: "./.sandcastle/merge-prompt.md",
@@ -218,7 +228,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     },
   });
 
-  console.log("\nBranches merged.");
+  console.log("\nPull requests opened.");
 }
 
 console.log("\nAll done.");

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -1,26 +1,55 @@
 # TASK
 
-Merge the following branches into the current branch:
+The following branches have been implemented and reviewed by Sandcastle agents:
 
 {{BRANCHES}}
 
+These branches are local-only. Your job is to publish each one as a pull
+request on GitHub so the human can review and merge it. **Do NOT merge any
+branch into the current branch yourself. Do NOT push to `main`.**
+
+Before doing anything else, ensure git can push using the sandbox's GitHub
+credentials. Run `gh auth setup-git` once — this configures git to use the
+`gh` CLI's token for HTTPS pushes. If the repo's `origin` remote uses SSH
+(e.g. `git@github.com:...`), switch it to HTTPS first:
+
+```
+gh repo set-default <owner>/<repo>   # optional, only if gh asks
+url=$(gh repo view --json url -q .url)
+git remote set-url origin "$url.git"
+```
+
 For each branch:
 
-1. Run `git merge <branch> --no-edit`
-2. If there are merge conflicts, resolve them intelligently by reading both sides and choosing the correct resolution
-3. After resolving conflicts, run `npm run typecheck` and `npm run test` to verify everything works
-4. If tests fail, fix the issues before proceeding to the next branch
+1. Check out the branch: `git checkout <branch>`
+2. Verify it has commits ahead of `origin/main`:
+   `git log --oneline origin/main..HEAD` — if empty, skip this branch.
+3. Sanity-check before publishing:
+   - `npm run typecheck` (or `tsc -b`)
+   - `npm test` (Vitest)
+   If either fails, do NOT push or open a PR for this branch — log the failure
+   and move on to the next branch.
+4. Push the branch to origin: `git push -u origin <branch>`
+5. Open a pull request with `gh pr create`:
+   - `--base main`
+   - `--head <branch>`
+   - `--title` and `--body` summarizing the change. The body MUST include
+     `Closes #<ID>` for the corresponding issue ID below so the issue
+     auto-closes when the human merges the PR.
+   - Use a HEREDOC for `--body` to get correct formatting.
+6. Print the resulting PR URL.
 
-After all branches are merged, make a single commit summarizing the merge.
+After processing every branch, return to `main`: `git checkout main`.
 
-# CLOSE ISSUES
+**Do NOT** run `git merge`, `git push origin main`, or `gh issue close` —
+issues will close automatically when the human merges the PR.
 
-For each branch that was merged, close its issue using the following command:
+# ISSUES
 
-`gh issue close <ID> --comment "Completed by Sandcastle"`
-
-Here are all the issues:
+Map each branch to its issue ID using this list (the issue ID is what goes
+into the `Closes #<ID>` line of the PR body):
 
 {{ISSUES}}
 
-Once you've merged everything you can, output <promise>COMPLETE</promise>.
+Once every branch has either been turned into a PR or skipped (with a
+reason logged), output <promise>COMPLETE</promise>.


### PR DESCRIPTION
## Summary
- Sandcastle's merge phase previously ran `git merge <branch>` directly into the current branch. When `npm run sandcastle` was invoked from `main`, that landed local commits on `main` (one bad push away from an auto-deploy) and never opened PRs.
- Renames Phase 3 from **Merge** to **Publish**: a single agent now pushes each completed branch to `origin` and opens a PR with `Closes #<ID>` in the body. The human reviews and merges, which auto-closes the issue.
- Adds a `gh auth setup-git` pre-flight (with SSH→HTTPS remote rewrite) so `git push` works inside the Docker sandbox where only the `gh` token is wired up.
- Explicitly forbids the publish agent from merging into the current branch, pushing main, or closing issues.

Motivation: a `npm run sandcastle` run from `main` produced 4 local commits on `main` and left issues #64 and #67 open. Recovered manually as PRs #68 and #69; this PR prevents a repeat.

## Test plan
- [x] Manual: run `npm run sandcastle` from `main`, confirm no commits land on `main` locally
- [x] Manual: confirm each completed branch produces a PR with `Closes #<ID>` in the body
- [x] Manual: confirm issues stay open until the PR is merged, then auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)