### PR TITLE
feat: add Data Cleanup admin tool for duplicate player/club merging

### DIFF
--- a/src/__tests__/dataCleanupHelpers.test.ts
+++ b/src/__tests__/dataCleanupHelpers.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   pickDefaultWinner,
   scoreColor,
+  areStintsOverlapping,
+  computeMergedRange,
   type PlayerCandidate,
   type ClubCandidate,
 } from "../pages/Admin/DataCleanup/helpers";
@@ -146,5 +148,101 @@ describe("scoreColor", () => {
     expect(scoreColor(0.69)).toBe("text-gray-400");
     expect(scoreColor(0.5)).toBe("text-gray-400");
     expect(scoreColor(0.0)).toBe("text-gray-400");
+  });
+});
+
+describe("areStintsOverlapping", () => {
+  it("detects overlapping year ranges", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "2018", year_departed: "2020" },
+      { year_joined: "2019", year_departed: "2021" },
+    )).toBe(true);
+  });
+
+  it("detects adjacent stints (departed = joined)", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "2015", year_departed: "2018" },
+      { year_joined: "2018", year_departed: "2021" },
+    )).toBe(true);
+  });
+
+  it("detects adjacent stints (gap of 1 year)", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "2015", year_departed: "2017" },
+      { year_joined: "2018", year_departed: "2021" },
+    )).toBe(true);
+  });
+
+  it("returns false for non-overlapping stints with gap > 1", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "2010", year_departed: "2013" },
+      { year_joined: "2018", year_departed: "2021" },
+    )).toBe(false);
+  });
+
+  it("handles empty year_departed as ongoing (current year)", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "2020", year_departed: "" },
+      { year_joined: "2022", year_departed: "2023" },
+    )).toBe(true);
+  });
+
+  it("handles empty year_joined as unknown — returns false", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "", year_departed: "2020" },
+      { year_joined: "2019", year_departed: "2021" },
+    )).toBe(false);
+  });
+
+  it("returns false when both year_joined are empty", () => {
+    expect(areStintsOverlapping(
+      { year_joined: "", year_departed: "" },
+      { year_joined: "", year_departed: "" },
+    )).toBe(false);
+  });
+
+  it("is commutative — order doesn't matter", () => {
+    const a = { year_joined: "2018", year_departed: "2020" };
+    const b = { year_joined: "2019", year_departed: "2021" };
+    expect(areStintsOverlapping(a, b)).toBe(areStintsOverlapping(b, a));
+  });
+});
+
+describe("computeMergedRange", () => {
+  it("returns earliest joined and latest departed", () => {
+    const result = computeMergedRange([
+      { year_joined: "2018", year_departed: "2020" },
+      { year_joined: "2019", year_departed: "2022" },
+    ]);
+    expect(result).toEqual({ year_joined: "2018", year_departed: "2022" });
+  });
+
+  it("preserves empty year_departed (ongoing stint)", () => {
+    const result = computeMergedRange([
+      { year_joined: "2018", year_departed: "2020" },
+      { year_joined: "2020", year_departed: "" },
+    ]);
+    expect(result).toEqual({ year_joined: "2018", year_departed: "" });
+  });
+
+  it("handles a single stint", () => {
+    const result = computeMergedRange([
+      { year_joined: "2015", year_departed: "2018" },
+    ]);
+    expect(result).toEqual({ year_joined: "2015", year_departed: "2018" });
+  });
+
+  it("merges three overlapping stints", () => {
+    const result = computeMergedRange([
+      { year_joined: "2010", year_departed: "2013" },
+      { year_joined: "2012", year_departed: "2015" },
+      { year_joined: "2014", year_departed: "2018" },
+    ]);
+    expect(result).toEqual({ year_joined: "2010", year_departed: "2018" });
+  });
+
+  it("returns empty strings for empty input", () => {
+    const result = computeMergedRange([]);
+    expect(result).toEqual({ year_joined: "", year_departed: "" });
   });
 });

--- a/src/__tests__/dataCleanupHelpers.test.ts
+++ b/src/__tests__/dataCleanupHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   scoreColor,
   areStintsOverlapping,
   computeMergedRange,
+  isFieldConflict,
 } from "../pages/Admin/DataCleanup/helpers";
 import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/types";
 
@@ -243,5 +244,27 @@ describe("computeMergedRange", () => {
   it("returns empty strings for empty input", () => {
     const result = computeMergedRange([]);
     expect(result).toEqual({ year_joined: "", year_departed: "" });
+  });
+});
+
+describe("isFieldConflict", () => {
+  it("returns true when both values are non-empty and different", () => {
+    expect(isFieldConflict("1990-01-15", "1990-02-20")).toBe(true);
+  });
+
+  it("returns false when values match", () => {
+    expect(isFieldConflict("1990-01-15", "1990-01-15")).toBe(false);
+  });
+
+  it("returns false when first value is empty", () => {
+    expect(isFieldConflict("", "1990-01-15")).toBe(false);
+  });
+
+  it("returns false when second value is empty", () => {
+    expect(isFieldConflict("1990-01-15", "")).toBe(false);
+  });
+
+  it("returns false when both values are empty", () => {
+    expect(isFieldConflict("", "")).toBe(false);
   });
 });

--- a/src/__tests__/dataCleanupHelpers.test.ts
+++ b/src/__tests__/dataCleanupHelpers.test.ts
@@ -4,9 +4,8 @@ import {
   scoreColor,
   areStintsOverlapping,
   computeMergedRange,
-  type PlayerCandidate,
-  type ClubCandidate,
 } from "../pages/Admin/DataCleanup/helpers";
+import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/types";
 
 function makePlayerCandidate(overrides: Partial<PlayerCandidate> = {}): PlayerCandidate {
   return {

--- a/src/__tests__/dataCleanupHelpers.test.ts
+++ b/src/__tests__/dataCleanupHelpers.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  pickDefaultWinner,
+  scoreColor,
+  type PlayerCandidate,
+  type ClubCandidate,
+} from "../pages/Admin/DataCleanup/helpers";
+
+function makePlayerCandidate(overrides: Partial<PlayerCandidate> = {}): PlayerCandidate {
+  return {
+    id_a: "p1",
+    id_b: "p2",
+    name_a: "Player A",
+    name_b: "Player B",
+    dob_a: "",
+    dob_b: "",
+    nationality_a: "",
+    nationality_b: "",
+    thumbnail_a: "",
+    thumbnail_b: "",
+    position_a: "",
+    position_b: "",
+    source_a: "transfermarkt",
+    source_b: "wikidata",
+    transfermarkt_id_a: null,
+    transfermarkt_id_b: null,
+    stint_count_a: 0,
+    stint_count_b: 0,
+    score: 0.85,
+    name_sim: 0.82,
+    dob_match: false,
+    same_nationality: false,
+    cross_source: true,
+    ...overrides,
+  };
+}
+
+function makeClubCandidate(overrides: Partial<ClubCandidate> = {}): ClubCandidate {
+  return {
+    id_a: "c1",
+    id_b: "c2",
+    name_a: "Club A",
+    name_b: "Club B",
+    country_a: "",
+    country_b: "",
+    badge_a: "",
+    badge_b: "",
+    player_count_a: 0,
+    player_count_b: 0,
+    score: 0.80,
+    name_sim: 0.75,
+    same_country: false,
+    roster_overlap: 0,
+    shared_player_count: 0,
+    ...overrides,
+  };
+}
+
+describe("pickDefaultWinner", () => {
+  describe("players", () => {
+    it("picks the player with more stints", () => {
+      const c = makePlayerCandidate({ stint_count_a: 5, stint_count_b: 3 });
+      expect(pickDefaultWinner(c)).toBe("a");
+    });
+
+    it("picks the other player if they have more stints", () => {
+      const c = makePlayerCandidate({ stint_count_a: 2, stint_count_b: 7 });
+      expect(pickDefaultWinner(c)).toBe("b");
+    });
+
+    it("breaks stint tie with transfermarkt_id", () => {
+      const c = makePlayerCandidate({
+        stint_count_a: 3,
+        stint_count_b: 3,
+        transfermarkt_id_a: null,
+        transfermarkt_id_b: "12345",
+      });
+      expect(pickDefaultWinner(c)).toBe("b");
+    });
+
+    it("breaks transfermarkt_id tie with thumbnail", () => {
+      const c = makePlayerCandidate({
+        stint_count_a: 3,
+        stint_count_b: 3,
+        transfermarkt_id_a: null,
+        transfermarkt_id_b: null,
+        thumbnail_a: "https://img.example.com/photo.jpg",
+        thumbnail_b: "",
+      });
+      expect(pickDefaultWinner(c)).toBe("a");
+    });
+
+    it("defaults to 'a' when all tiebreakers are equal", () => {
+      const c = makePlayerCandidate({
+        stint_count_a: 3,
+        stint_count_b: 3,
+      });
+      expect(pickDefaultWinner(c)).toBe("a");
+    });
+  });
+
+  describe("clubs", () => {
+    it("picks the club with more players", () => {
+      const c = makeClubCandidate({ player_count_a: 20, player_count_b: 5 });
+      expect(pickDefaultWinner(c)).toBe("a");
+    });
+
+    it("picks the other club if it has more players", () => {
+      const c = makeClubCandidate({ player_count_a: 3, player_count_b: 15 });
+      expect(pickDefaultWinner(c)).toBe("b");
+    });
+
+    it("breaks tie with badge presence", () => {
+      const c = makeClubCandidate({
+        player_count_a: 10,
+        player_count_b: 10,
+        badge_a: "",
+        badge_b: "https://img.example.com/badge.png",
+      });
+      expect(pickDefaultWinner(c)).toBe("b");
+    });
+
+    it("defaults to 'a' when all tiebreakers are equal", () => {
+      const c = makeClubCandidate({
+        player_count_a: 10,
+        player_count_b: 10,
+      });
+      expect(pickDefaultWinner(c)).toBe("a");
+    });
+  });
+});
+
+describe("scoreColor", () => {
+  it("returns green for scores >= 0.95", () => {
+    expect(scoreColor(0.95)).toBe("text-green-400");
+    expect(scoreColor(1.0)).toBe("text-green-400");
+  });
+
+  it("returns yellow for scores between 0.70 and 0.95", () => {
+    expect(scoreColor(0.70)).toBe("text-yellow-400");
+    expect(scoreColor(0.85)).toBe("text-yellow-400");
+    expect(scoreColor(0.949)).toBe("text-yellow-400");
+  });
+
+  it("returns gray for scores below 0.70", () => {
+    expect(scoreColor(0.69)).toBe("text-gray-400");
+    expect(scoreColor(0.5)).toBe("text-gray-400");
+    expect(scoreColor(0.0)).toBe("text-gray-400");
+  });
+});

--- a/src/api/dataCleanupApi.ts
+++ b/src/api/dataCleanupApi.ts
@@ -1,5 +1,5 @@
 import { supabase } from "./supabaseClient";
-import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/helpers";
+import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/types";
 import type { StintFragment, OrphanPlayer, OrphanClub } from "../pages/Admin/DataCleanup/types";
 
 export async function findDuplicatePlayerCandidates(

--- a/src/api/dataCleanupApi.ts
+++ b/src/api/dataCleanupApi.ts
@@ -1,6 +1,5 @@
 import { supabase } from "./supabaseClient";
-import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/types";
-import type { StintFragment, OrphanPlayer, OrphanClub } from "../pages/Admin/DataCleanup/types";
+import type { PlayerCandidate, ClubCandidate, StintFragment, OrphanPlayer, OrphanClub } from "../pages/Admin/DataCleanup/types";
 
 export async function findDuplicatePlayerCandidates(
   minScore = 0.55,

--- a/src/api/dataCleanupApi.ts
+++ b/src/api/dataCleanupApi.ts
@@ -1,0 +1,86 @@
+import { supabase } from "./supabaseClient";
+import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/helpers";
+
+export async function findDuplicatePlayerCandidates(
+  minScore = 0.55,
+  maxResults = 50,
+): Promise<PlayerCandidate[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_duplicate_player_candidates", {
+    min_score: minScore,
+    max_results: maxResults,
+  });
+  if (error) {
+    console.error("findDuplicatePlayerCandidates failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function findDuplicateClubCandidates(
+  minScore = 0.55,
+  maxResults = 50,
+): Promise<ClubCandidate[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_duplicate_club_candidates", {
+    min_score: minScore,
+    max_results: maxResults,
+  });
+  if (error) {
+    console.error("findDuplicateClubCandidates failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function dismissDuplicate(
+  entityType: "player" | "club",
+  idA: string,
+  idB: string,
+  reason = "",
+): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase.rpc("dismiss_duplicate", {
+    p_entity_type: entityType,
+    p_id_a: idA,
+    p_id_b: idB,
+    p_reason: reason,
+  });
+  if (error) {
+    console.error("dismissDuplicate failed:", error);
+    return false;
+  }
+  return true;
+}
+
+export async function mergePlayers(
+  winnerId: string,
+  loserId: string,
+): Promise<{ stints_moved: number; stints_dropped: number; schedule_moved: number } | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase.rpc("merge_players", {
+    p_winner_id: winnerId,
+    p_loser_id: loserId,
+  });
+  if (error) {
+    console.error("mergePlayers failed:", error);
+    return null;
+  }
+  return data;
+}
+
+export async function mergeClubs(
+  winnerId: string,
+  loserId: string,
+): Promise<{ stints_moved: number; stints_dropped: number; players_updated: number } | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase.rpc("merge_clubs", {
+    p_winner_id: winnerId,
+    p_loser_id: loserId,
+  });
+  if (error) {
+    console.error("mergeClubs failed:", error);
+    return null;
+  }
+  return data;
+}

--- a/src/api/dataCleanupApi.ts
+++ b/src/api/dataCleanupApi.ts
@@ -1,5 +1,5 @@
 import { supabase } from "./supabaseClient";
-import type { PlayerCandidate, ClubCandidate, StintFragment, OrphanPlayer, OrphanClub } from "../pages/Admin/DataCleanup/types";
+import type { PlayerCandidate, ClubCandidate, StintFragment, OrphanPlayer, OrphanClub, SharedClub, SharedPlayer } from "../pages/Admin/DataCleanup/types";
 
 export async function findDuplicatePlayerCandidates(
   minScore = 0.55,
@@ -161,4 +161,36 @@ export async function deleteOrphanClub(id: string): Promise<boolean> {
     return false;
   }
   return true;
+}
+
+export async function findSharedClubsForPlayers(
+  playerIdA: string,
+  playerIdB: string,
+): Promise<SharedClub[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_shared_clubs_for_players", {
+    p_player_a: playerIdA,
+    p_player_b: playerIdB,
+  });
+  if (error) {
+    console.error("findSharedClubsForPlayers failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function findSharedPlayersForClubs(
+  clubIdA: string,
+  clubIdB: string,
+): Promise<SharedPlayer[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_shared_players_for_clubs", {
+    p_club_a: clubIdA,
+    p_club_b: clubIdB,
+  });
+  if (error) {
+    console.error("findSharedPlayersForClubs failed:", error);
+    return [];
+  }
+  return data ?? [];
 }

--- a/src/api/dataCleanupApi.ts
+++ b/src/api/dataCleanupApi.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./supabaseClient";
 import type { PlayerCandidate, ClubCandidate } from "../pages/Admin/DataCleanup/helpers";
+import type { StintFragment, OrphanPlayer, OrphanClub } from "../pages/Admin/DataCleanup/types";
 
 export async function findDuplicatePlayerCandidates(
   minScore = 0.55,
@@ -83,4 +84,82 @@ export async function mergeClubs(
     return null;
   }
   return data;
+}
+
+export async function findFragmentedStints(
+  maxResults = 100,
+): Promise<StintFragment[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_fragmented_stints", {
+    max_results: maxResults,
+  });
+  if (error) {
+    console.error("findFragmentedStints failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function mergeStints(
+  playerId: string,
+  clubId: string,
+): Promise<{ stints_merged: number; kept_joined: string; kept_departed: string } | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase.rpc("merge_stints", {
+    p_player_id: playerId,
+    p_club_id: clubId,
+  });
+  if (error) {
+    console.error("mergeStints failed:", error);
+    return null;
+  }
+  return data;
+}
+
+export async function findOrphanPlayers(
+  maxResults = 100,
+): Promise<OrphanPlayer[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_orphan_players", {
+    max_results: maxResults,
+  });
+  if (error) {
+    console.error("findOrphanPlayers failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function findOrphanClubs(
+  maxResults = 100,
+): Promise<OrphanClub[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase.rpc("find_orphan_clubs", {
+    max_results: maxResults,
+  });
+  if (error) {
+    console.error("findOrphanClubs failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function deleteOrphanPlayer(id: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase.rpc("delete_orphan_player", { p_id: id });
+  if (error) {
+    console.error("deleteOrphanPlayer failed:", error);
+    return false;
+  }
+  return true;
+}
+
+export async function deleteOrphanClub(id: string): Promise<boolean> {
+  if (!supabase) return false;
+  const { error } = await supabase.rpc("delete_orphan_club", { p_id: id });
+  if (error) {
+    console.error("deleteOrphanClub failed:", error);
+    return false;
+  }
+  return true;
 }

--- a/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useClubCandidates } from "./useMergeCandidates";
-import { pickDefaultWinner, scoreColor } from "./helpers";
+import { pickDefaultWinner, scoreColor, isFieldConflict } from "./helpers";
 import type { ClubCandidate, WinnerSide } from "./types";
 
 function ScoreChips({ c }: { c: ClubCandidate }) {
@@ -48,7 +48,7 @@ function ClubSide({ c, side, selected, onSelect }: {
         )}
         <div>
           <div className="font-semibold text-white">{name}</div>
-          <div className="text-xs text-gray-400">{country || "—"}</div>
+          <div className={`text-xs ${isFieldConflict(c.country_a, c.country_b) ? "text-red-400" : "text-gray-400"}`}>{country || "—"}</div>
         </div>
       </div>
       <div className="text-xs text-gray-300">Players: {count}</div>

--- a/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useClubCandidates } from "./useMergeCandidates";
+import { findSharedPlayersForClubs } from "../../../api/dataCleanupApi";
 import { pickDefaultWinner, scoreColor, isFieldConflict } from "./helpers";
-import type { ClubCandidate, WinnerSide } from "./types";
+import type { ClubCandidate, WinnerSide, SharedPlayer } from "./types";
 
 function ScoreChips({ c }: { c: ClubCandidate }) {
   return (
@@ -57,6 +58,62 @@ function ClubSide({ c, side, selected, onSelect }: {
   );
 }
 
+function RosterOverlapPreview({ clubIdA, clubIdB, nameA, nameB }: {
+  clubIdA: string;
+  clubIdB: string;
+  nameA: string;
+  nameB: string;
+}) {
+  const [players, setPlayers] = useState<SharedPlayer[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!expanded) return;
+    let active = true;
+    findSharedPlayersForClubs(clubIdA, clubIdB).then((data) => {
+      if (active) { setPlayers(data); setLoaded(true); }
+    });
+    return () => { active = false; };
+  }, [clubIdA, clubIdB, expanded]);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+      >
+        {expanded ? "Hide" : "Show"} shared players
+      </button>
+      {expanded && (
+        <div className="mt-2">
+          {!loaded ? (
+            <p className="text-xs text-gray-500">Loading...</p>
+          ) : players.length === 0 ? (
+            <p className="text-xs text-gray-500">No shared players.</p>
+          ) : (
+            <div className="bg-gray-900/50 rounded-lg p-2 space-y-1 max-h-48 overflow-y-auto">
+              <div className="grid grid-cols-3 gap-2 text-xs text-gray-500 font-medium px-1">
+                <span>Player</span>
+                <span>{nameA}</span>
+                <span>{nameB}</span>
+              </div>
+              {players.map((p) => (
+                <div key={p.player_id} className="grid grid-cols-3 gap-2 text-xs text-gray-300 px-1">
+                  <span className="text-white">{p.player_name}</span>
+                  <span>{p.years_at_a}</span>
+                  <span>{p.years_at_b}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function CandidateRow({ c, onMerge, onDismiss }: {
   c: ClubCandidate;
   onMerge: (winnerId: string, loserId: string) => void;
@@ -78,6 +135,14 @@ function CandidateRow({ c, onMerge, onDismiss }: {
         <ClubSide c={c} side="a" selected={winner === "a"} onSelect={() => setWinner("a")} />
         <ClubSide c={c} side="b" selected={winner === "b"} onSelect={() => setWinner("b")} />
       </div>
+      {c.shared_player_count > 0 && (
+        <RosterOverlapPreview
+          clubIdA={c.id_a}
+          clubIdB={c.id_b}
+          nameA={c.name_a}
+          nameB={c.name_b}
+        />
+      )}
       <div className="flex gap-2 justify-end">
         <button
           type="button"

--- a/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { useClubCandidates } from "./useMergeCandidates";
+import { pickDefaultWinner, scoreColor, type ClubCandidate } from "./helpers";
+import type { WinnerSide } from "./types";
+
+function ScoreChips({ c }: { c: ClubCandidate }) {
+  return (
+    <div className="flex flex-wrap gap-1.5 text-xs">
+      <span className="bg-gray-700 px-2 py-0.5 rounded">name {c.name_sim.toFixed(2)}</span>
+      {c.same_country && <span className="bg-purple-900 text-purple-300 px-2 py-0.5 rounded">same country</span>}
+      {c.shared_player_count > 0 && (
+        <span className="bg-blue-900 text-blue-300 px-2 py-0.5 rounded">
+          {c.shared_player_count} shared players ({(c.roster_overlap * 100).toFixed(0)}%)
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ClubSide({ c, side, selected, onSelect }: {
+  c: ClubCandidate;
+  side: "a" | "b";
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const name = side === "a" ? c.name_a : c.name_b;
+  const badge = side === "a" ? c.badge_a : c.badge_b;
+  const country = side === "a" ? c.country_a : c.country_b;
+  const count = side === "a" ? c.player_count_a : c.player_count_b;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex-1 p-3 rounded-lg border-2 text-left transition-colors ${
+        selected
+          ? "border-green-500 bg-green-900/20"
+          : "border-gray-700 bg-gray-800 hover:border-gray-500"
+      }`}
+    >
+      <div className="flex items-center gap-3 mb-2">
+        {badge ? (
+          <img src={badge} alt="" className="w-10 h-10 object-contain" />
+        ) : (
+          <div className="w-10 h-10 rounded bg-gray-700 flex items-center justify-center text-gray-400 text-sm">
+            {name.slice(0, 2).toUpperCase()}
+          </div>
+        )}
+        <div>
+          <div className="font-semibold text-white">{name}</div>
+          <div className="text-xs text-gray-400">{country || "—"}</div>
+        </div>
+      </div>
+      <div className="text-xs text-gray-300">Players: {count}</div>
+      {selected && <div className="mt-2 text-green-400 text-xs font-semibold">WINNER (keep)</div>}
+    </button>
+  );
+}
+
+function CandidateRow({ c, onMerge, onDismiss }: {
+  c: ClubCandidate;
+  onMerge: (winnerId: string, loserId: string) => void;
+  onDismiss: (idA: string, idB: string) => void;
+}) {
+  const [winner, setWinner] = useState<WinnerSide>(pickDefaultWinner(c));
+  const [confirming, setConfirming] = useState(false);
+
+  const winnerId = winner === "a" ? c.id_a : c.id_b;
+  const loserId = winner === "a" ? c.id_b : c.id_a;
+
+  return (
+    <div className="bg-gray-800/50 rounded-xl p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <ScoreChips c={c} />
+        <span className={`text-lg font-bold ${scoreColor(c.score)}`}>{c.score.toFixed(2)}</span>
+      </div>
+      <div className="flex gap-3">
+        <ClubSide c={c} side="a" selected={winner === "a"} onSelect={() => setWinner("a")} />
+        <ClubSide c={c} side="b" selected={winner === "b"} onSelect={() => setWinner("b")} />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={() => onDismiss(c.id_a, c.id_b)}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors"
+        >
+          Not duplicate
+        </button>
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+          >
+            Merge
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-red-400">Delete {winner === "a" ? c.name_b : c.name_a}?</span>
+            <button
+              type="button"
+              onClick={() => { setConfirming(false); onMerge(winnerId, loserId); }}
+              className="px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DuplicateClubQueue() {
+  const { candidates, loading, error, refresh, dismiss, merge } = useClubCandidates();
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const handleMerge = async (winnerId: string, loserId: string) => {
+    const result = await merge(winnerId, loserId);
+    if (result) {
+      setLastResult(`Merged: ${result.stints_moved} stints moved, ${result.stints_dropped} dropped, ${result.players_updated} players updated`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Duplicate Clubs ({candidates.length})</h3>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {loading ? "Loading..." : "Refresh"}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {lastResult && <p className="text-green-400 text-sm">{lastResult}</p>}
+      {!loading && candidates.length === 0 && (
+        <p className="text-gray-500 text-sm">No duplicate candidates found.</p>
+      )}
+      {candidates.map((c) => (
+        <CandidateRow
+          key={`${c.id_a}-${c.id_b}`}
+          c={c}
+          onMerge={handleMerge}
+          onDismiss={dismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicateClubQueue.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useClubCandidates } from "./useMergeCandidates";
-import { pickDefaultWinner, scoreColor, type ClubCandidate } from "./helpers";
-import type { WinnerSide } from "./types";
+import { pickDefaultWinner, scoreColor } from "./helpers";
+import type { ClubCandidate, WinnerSide } from "./types";
 
 function ScoreChips({ c }: { c: ClubCandidate }) {
   return (

--- a/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { usePlayerCandidates } from "./useMergeCandidates";
+import { pickDefaultWinner, scoreColor, type PlayerCandidate } from "./helpers";
+import type { WinnerSide } from "./types";
+
+function ScoreChips({ c }: { c: PlayerCandidate }) {
+  return (
+    <div className="flex flex-wrap gap-1.5 text-xs">
+      <span className="bg-gray-700 px-2 py-0.5 rounded">name {c.name_sim.toFixed(2)}</span>
+      {c.dob_match && <span className="bg-blue-900 text-blue-300 px-2 py-0.5 rounded">DOB match</span>}
+      {c.same_nationality && <span className="bg-purple-900 text-purple-300 px-2 py-0.5 rounded">same nationality</span>}
+      {c.cross_source && <span className="bg-amber-900 text-amber-300 px-2 py-0.5 rounded">cross-source</span>}
+    </div>
+  );
+}
+
+function PlayerSide({ c, side, selected, onSelect }: {
+  c: PlayerCandidate;
+  side: "a" | "b";
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const name = side === "a" ? c.name_a : c.name_b;
+  const thumb = side === "a" ? c.thumbnail_a : c.thumbnail_b;
+  const dob = side === "a" ? c.dob_a : c.dob_b;
+  const nat = side === "a" ? c.nationality_a : c.nationality_b;
+  const pos = side === "a" ? c.position_a : c.position_b;
+  const src = side === "a" ? c.source_a : c.source_b;
+  const tmId = side === "a" ? c.transfermarkt_id_a : c.transfermarkt_id_b;
+  const stints = side === "a" ? c.stint_count_a : c.stint_count_b;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex-1 p-3 rounded-lg border-2 text-left transition-colors ${
+        selected
+          ? "border-green-500 bg-green-900/20"
+          : "border-gray-700 bg-gray-800 hover:border-gray-500"
+      }`}
+    >
+      <div className="flex items-center gap-3 mb-2">
+        {thumb ? (
+          <img src={thumb} alt="" className="w-10 h-10 rounded-full object-cover" />
+        ) : (
+          <div className="w-10 h-10 rounded-full bg-gray-700 flex items-center justify-center text-gray-400 text-sm">?</div>
+        )}
+        <div>
+          <div className="font-semibold text-white">{name}</div>
+          <div className="text-xs text-gray-400">{src}{tmId ? ` · TM#${tmId}` : ""}</div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-gray-300">
+        <span>DOB: {dob || "—"}</span>
+        <span>Nationality: {nat || "—"}</span>
+        <span>Position: {pos || "—"}</span>
+        <span>Stints: {stints}</span>
+      </div>
+      {selected && <div className="mt-2 text-green-400 text-xs font-semibold">WINNER (keep)</div>}
+    </button>
+  );
+}
+
+function CandidateRow({ c, onMerge, onDismiss }: {
+  c: PlayerCandidate;
+  onMerge: (winnerId: string, loserId: string) => void;
+  onDismiss: (idA: string, idB: string) => void;
+}) {
+  const [winner, setWinner] = useState<WinnerSide>(pickDefaultWinner(c));
+  const [confirming, setConfirming] = useState(false);
+
+  const winnerId = winner === "a" ? c.id_a : c.id_b;
+  const loserId = winner === "a" ? c.id_b : c.id_a;
+
+  return (
+    <div className="bg-gray-800/50 rounded-xl p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <ScoreChips c={c} />
+        <span className={`text-lg font-bold ${scoreColor(c.score)}`}>{c.score.toFixed(2)}</span>
+      </div>
+      <div className="flex gap-3">
+        <PlayerSide c={c} side="a" selected={winner === "a"} onSelect={() => setWinner("a")} />
+        <PlayerSide c={c} side="b" selected={winner === "b"} onSelect={() => setWinner("b")} />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={() => onDismiss(c.id_a, c.id_b)}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors"
+        >
+          Not duplicate
+        </button>
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+          >
+            Merge
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-red-400">Delete {winner === "a" ? c.name_b : c.name_a}?</span>
+            <button
+              type="button"
+              onClick={() => { setConfirming(false); onMerge(winnerId, loserId); }}
+              className="px-3 py-1.5 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DuplicatePlayerQueue() {
+  const { candidates, loading, error, refresh, dismiss, merge } = usePlayerCandidates();
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const handleMerge = async (winnerId: string, loserId: string) => {
+    const result = await merge(winnerId, loserId);
+    if (result) {
+      setLastResult(`Merged: ${result.stints_moved} stints moved, ${result.stints_dropped} dropped, ${result.schedule_moved} schedule entries moved`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Duplicate Players ({candidates.length})</h3>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {loading ? "Loading..." : "Refresh"}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {lastResult && <p className="text-green-400 text-sm">{lastResult}</p>}
+      {!loading && candidates.length === 0 && (
+        <p className="text-gray-500 text-sm">No duplicate candidates found.</p>
+      )}
+      {candidates.map((c) => (
+        <CandidateRow
+          key={`${c.id_a}-${c.id_b}`}
+          c={c}
+          onMerge={handleMerge}
+          onDismiss={dismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { usePlayerCandidates } from "./useMergeCandidates";
-import { pickDefaultWinner, scoreColor, type PlayerCandidate } from "./helpers";
-import type { WinnerSide } from "./types";
+import { pickDefaultWinner, scoreColor } from "./helpers";
+import type { PlayerCandidate, WinnerSide } from "./types";
 
 function ScoreChips({ c }: { c: PlayerCandidate }) {
   return (

--- a/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { usePlayerCandidates } from "./useMergeCandidates";
+import { findSharedClubsForPlayers } from "../../../api/dataCleanupApi";
 import { pickDefaultWinner, scoreColor, isFieldConflict } from "./helpers";
-import type { PlayerCandidate, WinnerSide } from "./types";
+import type { PlayerCandidate, WinnerSide, SharedClub } from "./types";
 
 function ScoreChips({ c }: { c: PlayerCandidate }) {
   return (
@@ -63,6 +64,33 @@ function PlayerSide({ c, side, selected, onSelect }: {
   );
 }
 
+function SharedClubs({ playerIdA, playerIdB }: { playerIdA: string; playerIdB: string }) {
+  const [clubs, setClubs] = useState<SharedClub[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    findSharedClubsForPlayers(playerIdA, playerIdB).then((data) => {
+      if (active) { setClubs(data); setLoaded(true); }
+    });
+    return () => { active = false; };
+  }, [playerIdA, playerIdB]);
+
+  if (!loaded || clubs.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-gray-400">
+      <span className="text-gray-500">Shared clubs:</span>
+      {clubs.map((club) => (
+        <span key={club.club_id} className="flex items-center gap-1 bg-gray-700/50 px-2 py-0.5 rounded">
+          {club.club_badge && <img src={club.club_badge} alt="" className="w-4 h-4 object-contain" />}
+          {club.club_name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function CandidateRow({ c, onMerge, onDismiss }: {
   c: PlayerCandidate;
   onMerge: (winnerId: string, loserId: string) => void;
@@ -84,6 +112,7 @@ function CandidateRow({ c, onMerge, onDismiss }: {
         <PlayerSide c={c} side="a" selected={winner === "a"} onSelect={() => setWinner("a")} />
         <PlayerSide c={c} side="b" selected={winner === "b"} onSelect={() => setWinner("b")} />
       </div>
+      <SharedClubs playerIdA={c.id_a} playerIdB={c.id_b} />
       <div className="flex gap-2 justify-end">
         <button
           type="button"

--- a/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
+++ b/src/pages/Admin/DataCleanup/DuplicatePlayerQueue.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { usePlayerCandidates } from "./useMergeCandidates";
-import { pickDefaultWinner, scoreColor } from "./helpers";
+import { pickDefaultWinner, scoreColor, isFieldConflict } from "./helpers";
 import type { PlayerCandidate, WinnerSide } from "./types";
 
 function ScoreChips({ c }: { c: PlayerCandidate }) {
@@ -29,6 +29,8 @@ function PlayerSide({ c, side, selected, onSelect }: {
   const tmId = side === "a" ? c.transfermarkt_id_a : c.transfermarkt_id_b;
   const stints = side === "a" ? c.stint_count_a : c.stint_count_b;
 
+  const conflict = (a: string, b: string) => isFieldConflict(a, b) ? "text-red-400" : "";
+
   return (
     <button
       type="button"
@@ -51,9 +53,9 @@ function PlayerSide({ c, side, selected, onSelect }: {
         </div>
       </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-gray-300">
-        <span>DOB: {dob || "—"}</span>
-        <span>Nationality: {nat || "—"}</span>
-        <span>Position: {pos || "—"}</span>
+        <span className={conflict(c.dob_a, c.dob_b)}>DOB: {dob || "—"}</span>
+        <span className={conflict(c.nationality_a, c.nationality_b)}>Nationality: {nat || "—"}</span>
+        <span className={conflict(c.position_a, c.position_b)}>Position: {pos || "—"}</span>
         <span>Stints: {stints}</span>
       </div>
       {selected && <div className="mt-2 text-green-400 text-xs font-semibold">WINNER (keep)</div>}

--- a/src/pages/Admin/DataCleanup/OrphanQueue.tsx
+++ b/src/pages/Admin/DataCleanup/OrphanQueue.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { useOrphanPlayers, useOrphanClubs } from "./useMergeCandidates";
+import type { OrphanPlayer, OrphanClub } from "./types";
+
+function OrphanPlayerRow({ p, onDelete }: {
+  p: OrphanPlayer;
+  onDelete: (id: string) => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div className="flex items-center justify-between bg-gray-800/50 rounded-lg px-4 py-3">
+      <div className="flex items-center gap-3">
+        {p.thumbnail ? (
+          <img src={p.thumbnail} alt="" className="w-8 h-8 rounded-full object-cover" />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center text-gray-400 text-xs">?</div>
+        )}
+        <div>
+          <div className="text-white text-sm font-medium">{p.name}</div>
+          <div className="text-xs text-gray-400">
+            {[p.nationality, p.date_born, p.data_source].filter(Boolean).join(" · ")}
+          </div>
+        </div>
+      </div>
+      {!confirming ? (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="px-3 py-1 text-xs text-red-400 hover:text-red-300 border border-red-800 rounded transition-colors"
+        >
+          Delete
+        </button>
+      ) : (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => { setConfirming(false); onDelete(p.id); }}
+            className="px-3 py-1 text-xs bg-red-600 hover:bg-red-700 text-white rounded transition-colors"
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="px-3 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OrphanClubRow({ c, onDelete }: {
+  c: OrphanClub;
+  onDelete: (id: string) => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div className="flex items-center justify-between bg-gray-800/50 rounded-lg px-4 py-3">
+      <div className="flex items-center gap-3">
+        {c.badge ? (
+          <img src={c.badge} alt="" className="w-8 h-8 object-contain" />
+        ) : (
+          <div className="w-8 h-8 rounded bg-gray-700 flex items-center justify-center text-gray-400 text-xs">
+            {c.name.slice(0, 2).toUpperCase()}
+          </div>
+        )}
+        <div>
+          <div className="text-white text-sm font-medium">{c.name}</div>
+          <div className="text-xs text-gray-400">{c.country || "—"}</div>
+        </div>
+      </div>
+      {!confirming ? (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="px-3 py-1 text-xs text-red-400 hover:text-red-300 border border-red-800 rounded transition-colors"
+        >
+          Delete
+        </button>
+      ) : (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => { setConfirming(false); onDelete(c.id); }}
+            className="px-3 py-1 text-xs bg-red-600 hover:bg-red-700 text-white rounded transition-colors"
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="px-3 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function OrphanQueue() {
+  const players = useOrphanPlayers();
+  const clubs = useOrphanClubs();
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Orphan Players ({players.orphans.length})</h3>
+          <button
+            type="button"
+            onClick={players.refresh}
+            disabled={players.loading}
+            className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors disabled:opacity-50"
+          >
+            {players.loading ? "Loading..." : "Refresh"}
+          </button>
+        </div>
+        <p className="text-xs text-gray-500">Players with zero club stints.</p>
+        {players.error && <p className="text-red-400 text-sm">{players.error}</p>}
+        {!players.loading && players.orphans.length === 0 && (
+          <p className="text-gray-500 text-sm">No orphan players found.</p>
+        )}
+        {players.orphans.map((p) => (
+          <OrphanPlayerRow key={p.id} p={p} onDelete={players.remove} />
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Orphan Clubs ({clubs.orphans.length})</h3>
+          <button
+            type="button"
+            onClick={clubs.refresh}
+            disabled={clubs.loading}
+            className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors disabled:opacity-50"
+          >
+            {clubs.loading ? "Loading..." : "Refresh"}
+          </button>
+        </div>
+        <p className="text-xs text-gray-500">
+          Clubs with zero player stints, not used in any pack or as a current club.
+        </p>
+        {clubs.error && <p className="text-red-400 text-sm">{clubs.error}</p>}
+        {!clubs.loading && clubs.orphans.length === 0 && (
+          <p className="text-gray-500 text-sm">No orphan clubs found.</p>
+        )}
+        {clubs.orphans.map((c) => (
+          <OrphanClubRow key={c.id} c={c} onDelete={clubs.remove} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Admin/DataCleanup/StintCleanupQueue.tsx
+++ b/src/pages/Admin/DataCleanup/StintCleanupQueue.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { useFragmentedStints } from "./useMergeCandidates";
+import type { StintFragment } from "./types";
+
+function FragmentRow({ f, onMerge }: {
+  f: StintFragment;
+  onMerge: (playerId: string, clubId: string) => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div className="bg-gray-800/50 rounded-xl p-4 space-y-2">
+      <div className="flex items-center justify-between">
+        <div>
+          <span className="font-semibold text-white">{f.player_name}</span>
+          <span className="text-gray-400 mx-2">at</span>
+          <span className="font-semibold text-white">{f.club_name}</span>
+        </div>
+        <span className="text-xs bg-amber-900 text-amber-300 px-2 py-0.5 rounded">
+          {f.stint_count} stints
+        </span>
+      </div>
+      <div className="text-sm text-gray-300">
+        Range: {f.earliest_joined || "?"} — {f.latest_departed || "present"}
+      </div>
+      <div className="flex gap-2 justify-end">
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+          >
+            Merge stints
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-blue-400">
+              Combine into {f.earliest_joined || "?"} — {f.latest_departed || "present"}?
+            </span>
+            <button
+              type="button"
+              onClick={() => { setConfirming(false); onMerge(f.player_id, f.club_id); }}
+              className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function StintCleanupQueue() {
+  const { fragments, loading, error, refresh, mergeStints } = useFragmentedStints();
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const handleMerge = async (playerId: string, clubId: string) => {
+    const result = await mergeStints(playerId, clubId);
+    if (result) {
+      setLastResult(
+        `Merged ${result.stints_merged} stints → ${result.kept_joined || "?"} — ${result.kept_departed || "present"}`,
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Fragmented Stints ({fragments.length})</h3>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white border border-gray-600 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {loading ? "Loading..." : "Refresh"}
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {lastResult && <p className="text-green-400 text-sm">{lastResult}</p>}
+      {!loading && fragments.length === 0 && (
+        <p className="text-gray-500 text-sm">No fragmented stints found.</p>
+      )}
+      {fragments.map((f) => (
+        <FragmentRow
+          key={`${f.player_id}-${f.club_id}`}
+          f={f}
+          onMerge={handleMerge}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -44,25 +44,23 @@ export interface ClubCandidate {
 
 export function pickDefaultWinner(c: PlayerCandidate | ClubCandidate): "a" | "b" {
   if ("stint_count_a" in c) {
-    const p = c as PlayerCandidate;
-    if (p.stint_count_a !== p.stint_count_b) {
-      return p.stint_count_a > p.stint_count_b ? "a" : "b";
+    if (c.stint_count_a !== c.stint_count_b) {
+      return c.stint_count_a > c.stint_count_b ? "a" : "b";
     }
-    if (Boolean(p.transfermarkt_id_a) !== Boolean(p.transfermarkt_id_b)) {
-      return p.transfermarkt_id_a ? "a" : "b";
+    if (Boolean(c.transfermarkt_id_a) !== Boolean(c.transfermarkt_id_b)) {
+      return c.transfermarkt_id_a ? "a" : "b";
     }
-    if (Boolean(p.thumbnail_a) !== Boolean(p.thumbnail_b)) {
-      return p.thumbnail_a ? "a" : "b";
+    if (Boolean(c.thumbnail_a) !== Boolean(c.thumbnail_b)) {
+      return c.thumbnail_a ? "a" : "b";
     }
     return "a";
   }
 
-  const club = c as ClubCandidate;
-  if (club.player_count_a !== club.player_count_b) {
-    return club.player_count_a > club.player_count_b ? "a" : "b";
+  if (c.player_count_a !== c.player_count_b) {
+    return c.player_count_a > c.player_count_b ? "a" : "b";
   }
-  if (Boolean(club.badge_a) !== Boolean(club.badge_b)) {
-    return club.badge_a ? "a" : "b";
+  if (Boolean(c.badge_a) !== Boolean(c.badge_b)) {
+    return c.badge_a ? "a" : "b";
   }
   return "a";
 }

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -1,0 +1,74 @@
+export interface PlayerCandidate {
+  id_a: string;
+  id_b: string;
+  name_a: string;
+  name_b: string;
+  dob_a: string;
+  dob_b: string;
+  nationality_a: string;
+  nationality_b: string;
+  thumbnail_a: string;
+  thumbnail_b: string;
+  position_a: string;
+  position_b: string;
+  source_a: string;
+  source_b: string;
+  transfermarkt_id_a: string | null;
+  transfermarkt_id_b: string | null;
+  stint_count_a: number;
+  stint_count_b: number;
+  score: number;
+  name_sim: number;
+  dob_match: boolean;
+  same_nationality: boolean;
+  cross_source: boolean;
+}
+
+export interface ClubCandidate {
+  id_a: string;
+  id_b: string;
+  name_a: string;
+  name_b: string;
+  country_a: string;
+  country_b: string;
+  badge_a: string;
+  badge_b: string;
+  player_count_a: number;
+  player_count_b: number;
+  score: number;
+  name_sim: number;
+  same_country: boolean;
+  roster_overlap: number;
+  shared_player_count: number;
+}
+
+export function pickDefaultWinner(c: PlayerCandidate | ClubCandidate): "a" | "b" {
+  if ("stint_count_a" in c) {
+    const p = c as PlayerCandidate;
+    if (p.stint_count_a !== p.stint_count_b) {
+      return p.stint_count_a > p.stint_count_b ? "a" : "b";
+    }
+    if (Boolean(p.transfermarkt_id_a) !== Boolean(p.transfermarkt_id_b)) {
+      return p.transfermarkt_id_a ? "a" : "b";
+    }
+    if (Boolean(p.thumbnail_a) !== Boolean(p.thumbnail_b)) {
+      return p.thumbnail_a ? "a" : "b";
+    }
+    return "a";
+  }
+
+  const club = c as ClubCandidate;
+  if (club.player_count_a !== club.player_count_b) {
+    return club.player_count_a > club.player_count_b ? "a" : "b";
+  }
+  if (Boolean(club.badge_a) !== Boolean(club.badge_b)) {
+    return club.badge_a ? "a" : "b";
+  }
+  return "a";
+}
+
+export function scoreColor(score: number): string {
+  if (score >= 0.95) return "text-green-400";
+  if (score >= 0.70) return "text-yellow-400";
+  return "text-gray-400";
+}

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -74,8 +74,13 @@ export function computeMergedRange(stints: YearRange[]): YearRange {
     }
   }
 
+  let departed = "";
+  if (!hasOngoing && latest !== -Infinity) {
+    departed = String(latest);
+  }
+
   return {
     year_joined: earliest === Infinity ? "" : String(earliest),
-    year_departed: hasOngoing ? "" : (latest === -Infinity ? "" : String(latest)),
+    year_departed: departed,
   };
 }

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -23,6 +23,10 @@ export function pickDefaultWinner(c: PlayerCandidate | ClubCandidate): WinnerSid
   return "a";
 }
 
+export function isFieldConflict(a: string, b: string): boolean {
+  return a !== "" && b !== "" && a !== b;
+}
+
 export function scoreColor(score: number): string {
   if (score >= 0.95) return "text-green-400";
   if (score >= 0.70) return "text-yellow-400";

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -70,3 +70,50 @@ export function scoreColor(score: number): string {
   if (score >= 0.70) return "text-yellow-400";
   return "text-gray-400";
 }
+
+interface YearRange {
+  year_joined: string;
+  year_departed: string;
+}
+
+function parseYear(s: string): number | null {
+  if (!s) return null;
+  const n = parseInt(s, 10);
+  return isNaN(n) ? null : n;
+}
+
+export function areStintsOverlapping(a: YearRange, b: YearRange): boolean {
+  const aStart = parseYear(a.year_joined);
+  const bStart = parseYear(b.year_joined);
+  if (aStart === null || bStart === null) return false;
+
+  const currentYear = new Date().getFullYear();
+  const aEnd = parseYear(a.year_departed) ?? currentYear;
+  const bEnd = parseYear(b.year_departed) ?? currentYear;
+
+  return aStart <= bEnd + 1 && bStart <= aEnd + 1;
+}
+
+export function computeMergedRange(stints: YearRange[]): YearRange {
+  if (stints.length === 0) return { year_joined: "", year_departed: "" };
+
+  let earliest = Infinity;
+  let latest = -Infinity;
+  let hasOngoing = false;
+
+  for (const s of stints) {
+    const start = parseYear(s.year_joined);
+    if (start !== null && start < earliest) earliest = start;
+    if (!s.year_departed) {
+      hasOngoing = true;
+    } else {
+      const end = parseYear(s.year_departed);
+      if (end !== null && end > latest) latest = end;
+    }
+  }
+
+  return {
+    year_joined: earliest === Infinity ? "" : String(earliest),
+    year_departed: hasOngoing ? "" : (latest === -Infinity ? "" : String(latest)),
+  };
+}

--- a/src/pages/Admin/DataCleanup/helpers.ts
+++ b/src/pages/Admin/DataCleanup/helpers.ts
@@ -1,48 +1,6 @@
-export interface PlayerCandidate {
-  id_a: string;
-  id_b: string;
-  name_a: string;
-  name_b: string;
-  dob_a: string;
-  dob_b: string;
-  nationality_a: string;
-  nationality_b: string;
-  thumbnail_a: string;
-  thumbnail_b: string;
-  position_a: string;
-  position_b: string;
-  source_a: string;
-  source_b: string;
-  transfermarkt_id_a: string | null;
-  transfermarkt_id_b: string | null;
-  stint_count_a: number;
-  stint_count_b: number;
-  score: number;
-  name_sim: number;
-  dob_match: boolean;
-  same_nationality: boolean;
-  cross_source: boolean;
-}
+import type { PlayerCandidate, ClubCandidate, WinnerSide } from "./types";
 
-export interface ClubCandidate {
-  id_a: string;
-  id_b: string;
-  name_a: string;
-  name_b: string;
-  country_a: string;
-  country_b: string;
-  badge_a: string;
-  badge_b: string;
-  player_count_a: number;
-  player_count_b: number;
-  score: number;
-  name_sim: number;
-  same_country: boolean;
-  roster_overlap: number;
-  shared_player_count: number;
-}
-
-export function pickDefaultWinner(c: PlayerCandidate | ClubCandidate): "a" | "b" {
+export function pickDefaultWinner(c: PlayerCandidate | ClubCandidate): WinnerSide {
   if ("stint_count_a" in c) {
     if (c.stint_count_a !== c.stint_count_b) {
       return c.stint_count_a > c.stint_count_b ? "a" : "b";

--- a/src/pages/Admin/DataCleanup/index.tsx
+++ b/src/pages/Admin/DataCleanup/index.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import DuplicatePlayerQueue from "./DuplicatePlayerQueue";
+import DuplicateClubQueue from "./DuplicateClubQueue";
+import type { CleanupTab } from "./types";
+
+export default function DataCleanup() {
+  const [tab, setTab] = useState<CleanupTab>("players");
+
+  return (
+    <div>
+      <nav className="flex gap-2 border-b border-gray-700 mb-4">
+        <button
+          type="button"
+          onClick={() => setTab("players")}
+          className={`px-3 py-1.5 -mb-px border-b-2 text-sm transition-colors ${
+            tab === "players"
+              ? "border-green-500 text-white"
+              : "border-transparent text-gray-400 hover:text-white"
+          }`}
+        >
+          Players
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("clubs")}
+          className={`px-3 py-1.5 -mb-px border-b-2 text-sm transition-colors ${
+            tab === "clubs"
+              ? "border-green-500 text-white"
+              : "border-transparent text-gray-400 hover:text-white"
+          }`}
+        >
+          Clubs
+        </button>
+      </nav>
+      {tab === "players" && <DuplicatePlayerQueue />}
+      {tab === "clubs" && <DuplicateClubQueue />}
+    </div>
+  );
+}

--- a/src/pages/Admin/DataCleanup/index.tsx
+++ b/src/pages/Admin/DataCleanup/index.tsx
@@ -1,7 +1,16 @@
 import { useState } from "react";
 import DuplicatePlayerQueue from "./DuplicatePlayerQueue";
 import DuplicateClubQueue from "./DuplicateClubQueue";
+import StintCleanupQueue from "./StintCleanupQueue";
+import OrphanQueue from "./OrphanQueue";
 import type { CleanupTab } from "./types";
+
+const tabs: { key: CleanupTab; label: string }[] = [
+  { key: "players", label: "Players" },
+  { key: "clubs", label: "Clubs" },
+  { key: "stints", label: "Stints" },
+  { key: "orphans", label: "Orphans" },
+];
 
 export default function DataCleanup() {
   const [tab, setTab] = useState<CleanupTab>("players");
@@ -9,31 +18,25 @@ export default function DataCleanup() {
   return (
     <div>
       <nav className="flex gap-2 border-b border-gray-700 mb-4">
-        <button
-          type="button"
-          onClick={() => setTab("players")}
-          className={`px-3 py-1.5 -mb-px border-b-2 text-sm transition-colors ${
-            tab === "players"
-              ? "border-green-500 text-white"
-              : "border-transparent text-gray-400 hover:text-white"
-          }`}
-        >
-          Players
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab("clubs")}
-          className={`px-3 py-1.5 -mb-px border-b-2 text-sm transition-colors ${
-            tab === "clubs"
-              ? "border-green-500 text-white"
-              : "border-transparent text-gray-400 hover:text-white"
-          }`}
-        >
-          Clubs
-        </button>
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={`px-3 py-1.5 -mb-px border-b-2 text-sm transition-colors ${
+              tab === t.key
+                ? "border-green-500 text-white"
+                : "border-transparent text-gray-400 hover:text-white"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
       </nav>
       {tab === "players" && <DuplicatePlayerQueue />}
       {tab === "clubs" && <DuplicateClubQueue />}
+      {tab === "stints" && <StintCleanupQueue />}
+      {tab === "orphans" && <OrphanQueue />}
     </div>
   );
 }

--- a/src/pages/Admin/DataCleanup/types.ts
+++ b/src/pages/Admin/DataCleanup/types.ts
@@ -1,6 +1,50 @@
 export type WinnerSide = "a" | "b";
 export type CleanupTab = "players" | "clubs" | "stints" | "orphans";
 
+export interface PlayerCandidate {
+  id_a: string;
+  id_b: string;
+  name_a: string;
+  name_b: string;
+  dob_a: string;
+  dob_b: string;
+  nationality_a: string;
+  nationality_b: string;
+  thumbnail_a: string;
+  thumbnail_b: string;
+  position_a: string;
+  position_b: string;
+  source_a: string;
+  source_b: string;
+  transfermarkt_id_a: string | null;
+  transfermarkt_id_b: string | null;
+  stint_count_a: number;
+  stint_count_b: number;
+  score: number;
+  name_sim: number;
+  dob_match: boolean;
+  same_nationality: boolean;
+  cross_source: boolean;
+}
+
+export interface ClubCandidate {
+  id_a: string;
+  id_b: string;
+  name_a: string;
+  name_b: string;
+  country_a: string;
+  country_b: string;
+  badge_a: string;
+  badge_b: string;
+  player_count_a: number;
+  player_count_b: number;
+  score: number;
+  name_sim: number;
+  same_country: boolean;
+  roster_overlap: number;
+  shared_player_count: number;
+}
+
 export interface StintFragment {
   player_id: string;
   player_name: string;

--- a/src/pages/Admin/DataCleanup/types.ts
+++ b/src/pages/Admin/DataCleanup/types.ts
@@ -1,0 +1,2 @@
+export type WinnerSide = "a" | "b";
+export type CleanupTab = "players" | "clubs";

--- a/src/pages/Admin/DataCleanup/types.ts
+++ b/src/pages/Admin/DataCleanup/types.ts
@@ -1,2 +1,28 @@
 export type WinnerSide = "a" | "b";
-export type CleanupTab = "players" | "clubs";
+export type CleanupTab = "players" | "clubs" | "stints" | "orphans";
+
+export interface StintFragment {
+  player_id: string;
+  player_name: string;
+  club_id: string;
+  club_name: string;
+  stint_count: number;
+  earliest_joined: string;
+  latest_departed: string;
+}
+
+export interface OrphanPlayer {
+  id: string;
+  name: string;
+  date_born: string;
+  nationality: string;
+  data_source: string;
+  thumbnail: string;
+}
+
+export interface OrphanClub {
+  id: string;
+  name: string;
+  country: string;
+  badge: string;
+}

--- a/src/pages/Admin/DataCleanup/types.ts
+++ b/src/pages/Admin/DataCleanup/types.ts
@@ -70,3 +70,16 @@ export interface OrphanClub {
   country: string;
   badge: string;
 }
+
+export interface SharedClub {
+  club_id: string;
+  club_name: string;
+  club_badge: string;
+}
+
+export interface SharedPlayer {
+  player_id: string;
+  player_name: string;
+  years_at_a: string;
+  years_at_b: string;
+}

--- a/src/pages/Admin/DataCleanup/useMergeCandidates.ts
+++ b/src/pages/Admin/DataCleanup/useMergeCandidates.ts
@@ -5,8 +5,15 @@ import {
   dismissDuplicate,
   mergePlayers,
   mergeClubs,
+  findFragmentedStints,
+  mergeStints as mergeStintsApi,
+  findOrphanPlayers,
+  findOrphanClubs,
+  deleteOrphanPlayer,
+  deleteOrphanClub,
 } from "../../../api/dataCleanupApi";
 import type { PlayerCandidate, ClubCandidate } from "./helpers";
+import type { StintFragment, OrphanPlayer, OrphanClub } from "./types";
 
 export function usePlayerCandidates(minScore = 0.55) {
   const [candidates, setCandidates] = useState<PlayerCandidate[]>([]);
@@ -80,4 +87,93 @@ export function useClubCandidates(minScore = 0.55) {
   };
 
   return { candidates, loading, error, refresh, dismiss, merge };
+}
+
+export function useFragmentedStints() {
+  const [fragments, setFragments] = useState<StintFragment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await findFragmentedStints();
+    setFragments(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const mergeStints = async (playerId: string, clubId: string) => {
+    setError(null);
+    const result = await mergeStintsApi(playerId, clubId);
+    if (!result) {
+      setError("Stint merge failed — check console for details");
+      return null;
+    }
+    setFragments((prev) => prev.filter(
+      (f) => !(f.player_id === playerId && f.club_id === clubId),
+    ));
+    return result;
+  };
+
+  return { fragments, loading, error, refresh, mergeStints };
+}
+
+export function useOrphanPlayers() {
+  const [orphans, setOrphans] = useState<OrphanPlayer[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await findOrphanPlayers();
+    setOrphans(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const remove = async (id: string) => {
+    setError(null);
+    const ok = await deleteOrphanPlayer(id);
+    if (!ok) {
+      setError("Delete failed — check console for details");
+      return false;
+    }
+    setOrphans((prev) => prev.filter((p) => p.id !== id));
+    return true;
+  };
+
+  return { orphans, loading, error, refresh, remove };
+}
+
+export function useOrphanClubs() {
+  const [orphans, setOrphans] = useState<OrphanClub[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await findOrphanClubs();
+    setOrphans(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const remove = async (id: string) => {
+    setError(null);
+    const ok = await deleteOrphanClub(id);
+    if (!ok) {
+      setError("Delete failed — check console for details");
+      return false;
+    }
+    setOrphans((prev) => prev.filter((c) => c.id !== id));
+    return true;
+  };
+
+  return { orphans, loading, error, refresh, remove };
 }

--- a/src/pages/Admin/DataCleanup/useMergeCandidates.ts
+++ b/src/pages/Admin/DataCleanup/useMergeCandidates.ts
@@ -16,8 +16,16 @@ import type { PlayerCandidate, ClubCandidate, StintFragment, OrphanPlayer, Orpha
 
 export function usePlayerCandidates(minScore = 0.55) {
   const [candidates, setCandidates] = useState<PlayerCandidate[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    findDuplicatePlayerCandidates(minScore).then((data) => {
+      if (active) { setCandidates(data); setLoading(false); }
+    });
+    return () => { active = false; };
+  }, [minScore]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -26,8 +34,6 @@ export function usePlayerCandidates(minScore = 0.55) {
     setCandidates(data);
     setLoading(false);
   }, [minScore]);
-
-  useEffect(() => { refresh(); }, [refresh]);
 
   const dismiss = async (idA: string, idB: string, reason = "") => {
     const ok = await dismissDuplicate("player", idA, idB, reason);
@@ -53,8 +59,16 @@ export function usePlayerCandidates(minScore = 0.55) {
 
 export function useClubCandidates(minScore = 0.55) {
   const [candidates, setCandidates] = useState<ClubCandidate[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    findDuplicateClubCandidates(minScore).then((data) => {
+      if (active) { setCandidates(data); setLoading(false); }
+    });
+    return () => { active = false; };
+  }, [minScore]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -63,8 +77,6 @@ export function useClubCandidates(minScore = 0.55) {
     setCandidates(data);
     setLoading(false);
   }, [minScore]);
-
-  useEffect(() => { refresh(); }, [refresh]);
 
   const dismiss = async (idA: string, idB: string, reason = "") => {
     const ok = await dismissDuplicate("club", idA, idB, reason);
@@ -90,8 +102,16 @@ export function useClubCandidates(minScore = 0.55) {
 
 export function useFragmentedStints() {
   const [fragments, setFragments] = useState<StintFragment[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    findFragmentedStints().then((data) => {
+      if (active) { setFragments(data); setLoading(false); }
+    });
+    return () => { active = false; };
+  }, []);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -100,8 +120,6 @@ export function useFragmentedStints() {
     setFragments(data);
     setLoading(false);
   }, []);
-
-  useEffect(() => { refresh(); }, [refresh]);
 
   const mergeStints = async (playerId: string, clubId: string) => {
     setError(null);
@@ -121,8 +139,16 @@ export function useFragmentedStints() {
 
 export function useOrphanPlayers() {
   const [orphans, setOrphans] = useState<OrphanPlayer[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    findOrphanPlayers().then((data) => {
+      if (active) { setOrphans(data); setLoading(false); }
+    });
+    return () => { active = false; };
+  }, []);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -131,8 +157,6 @@ export function useOrphanPlayers() {
     setOrphans(data);
     setLoading(false);
   }, []);
-
-  useEffect(() => { refresh(); }, [refresh]);
 
   const remove = async (id: string) => {
     setError(null);
@@ -150,8 +174,16 @@ export function useOrphanPlayers() {
 
 export function useOrphanClubs() {
   const [orphans, setOrphans] = useState<OrphanClub[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    findOrphanClubs().then((data) => {
+      if (active) { setOrphans(data); setLoading(false); }
+    });
+    return () => { active = false; };
+  }, []);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -160,8 +192,6 @@ export function useOrphanClubs() {
     setOrphans(data);
     setLoading(false);
   }, []);
-
-  useEffect(() => { refresh(); }, [refresh]);
 
   const remove = async (id: string) => {
     setError(null);

--- a/src/pages/Admin/DataCleanup/useMergeCandidates.ts
+++ b/src/pages/Admin/DataCleanup/useMergeCandidates.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  findDuplicatePlayerCandidates,
+  findDuplicateClubCandidates,
+  dismissDuplicate,
+  mergePlayers,
+  mergeClubs,
+} from "../../../api/dataCleanupApi";
+import type { PlayerCandidate, ClubCandidate } from "./helpers";
+
+export function usePlayerCandidates(minScore = 0.55) {
+  const [candidates, setCandidates] = useState<PlayerCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await findDuplicatePlayerCandidates(minScore);
+    setCandidates(data);
+    setLoading(false);
+  }, [minScore]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const dismiss = async (idA: string, idB: string, reason = "") => {
+    const ok = await dismissDuplicate("player", idA, idB, reason);
+    if (ok) setCandidates((prev) => prev.filter((c) => !(c.id_a === idA && c.id_b === idB)));
+    return ok;
+  };
+
+  const merge = async (winnerId: string, loserId: string) => {
+    setError(null);
+    const result = await mergePlayers(winnerId, loserId);
+    if (!result) {
+      setError("Merge failed — check console for details");
+      return null;
+    }
+    setCandidates((prev) => prev.filter(
+      (c) => c.id_a !== loserId && c.id_b !== loserId,
+    ));
+    return result;
+  };
+
+  return { candidates, loading, error, refresh, dismiss, merge };
+}
+
+export function useClubCandidates(minScore = 0.55) {
+  const [candidates, setCandidates] = useState<ClubCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await findDuplicateClubCandidates(minScore);
+    setCandidates(data);
+    setLoading(false);
+  }, [minScore]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const dismiss = async (idA: string, idB: string, reason = "") => {
+    const ok = await dismissDuplicate("club", idA, idB, reason);
+    if (ok) setCandidates((prev) => prev.filter((c) => !(c.id_a === idA && c.id_b === idB)));
+    return ok;
+  };
+
+  const merge = async (winnerId: string, loserId: string) => {
+    setError(null);
+    const result = await mergeClubs(winnerId, loserId);
+    if (!result) {
+      setError("Merge failed — check console for details");
+      return null;
+    }
+    setCandidates((prev) => prev.filter(
+      (c) => c.id_a !== loserId && c.id_b !== loserId,
+    ));
+    return result;
+  };
+
+  return { candidates, loading, error, refresh, dismiss, merge };
+}

--- a/src/pages/Admin/DataCleanup/useMergeCandidates.ts
+++ b/src/pages/Admin/DataCleanup/useMergeCandidates.ts
@@ -12,8 +12,7 @@ import {
   deleteOrphanPlayer,
   deleteOrphanClub,
 } from "../../../api/dataCleanupApi";
-import type { PlayerCandidate, ClubCandidate } from "./helpers";
-import type { StintFragment, OrphanPlayer, OrphanClub } from "./types";
+import type { PlayerCandidate, ClubCandidate, StintFragment, OrphanPlayer, OrphanClub } from "./types";
 
 export function usePlayerCandidates(minScore = 0.55) {
   const [candidates, setCandidates] = useState<PlayerCandidate[]>([]);

--- a/src/pages/Admin/index.tsx
+++ b/src/pages/Admin/index.tsx
@@ -3,8 +3,9 @@ import { Link } from "react-router-dom";
 import { useAdminAuth } from "../../api/useAdminAuth";
 import ScheduleManager from "./ScheduleManager";
 import PackBuilder from "./PackBuilder";
+import DataCleanup from "./DataCleanup";
 
-type AdminTab = "schedule" | "pack";
+type AdminTab = "schedule" | "pack" | "cleanup";
 
 function SignInForm({ onSignIn, error }: { onSignIn: (email: string, password: string) => void; error: string | null }) {
   const [email, setEmail] = useState("");
@@ -102,10 +103,23 @@ export default function Admin() {
           >
             Pack Builder
           </button>
+          <button
+            role="tab"
+            aria-selected={tab === "cleanup"}
+            onClick={() => setTab("cleanup")}
+            className={`px-4 py-2 -mb-px border-b-2 transition-colors ${
+              tab === "cleanup"
+                ? "border-green-500 text-white"
+                : "border-transparent text-gray-400 hover:text-white"
+            }`}
+          >
+            Data Cleanup
+          </button>
         </nav>
 
         {tab === "schedule" && <ScheduleManager />}
         {tab === "pack" && <PackBuilder />}
+        {tab === "cleanup" && <DataCleanup />}
       </div>
     </div>
   );

--- a/supabase/migrations/013_data_cleanup.sql
+++ b/supabase/migrations/013_data_cleanup.sql
@@ -1,0 +1,442 @@
+-- Enable pg_trgm for fuzzy name matching
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- GIN trigram indexes for candidate search
+CREATE INDEX IF NOT EXISTS idx_players_name_trgm
+  ON players USING gin (unaccent(name) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_clubs_name_trgm
+  ON clubs USING gin (unaccent(name) gin_trgm_ops);
+
+-- Dismissed duplicate pairs (admin-rejected, order-agnostic)
+CREATE TABLE IF NOT EXISTS duplicate_dismissals (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('player', 'club')),
+  id_a        TEXT NOT NULL,
+  id_b        TEXT NOT NULL,
+  reason      TEXT DEFAULT '',
+  dismissed_by TEXT DEFAULT '',
+  created_at  TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT unique_dismissal UNIQUE (entity_type, id_a, id_b),
+  CONSTRAINT ordered_ids CHECK (id_a < id_b)
+);
+
+-- Merge audit log (append-only)
+CREATE TABLE IF NOT EXISTS merge_log (
+  id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  entity_type    TEXT NOT NULL CHECK (entity_type IN ('player', 'club')),
+  winner_id      TEXT NOT NULL,
+  loser_id       TEXT NOT NULL,
+  loser_snapshot JSONB NOT NULL,
+  rows_moved     JSONB DEFAULT '{}',
+  merged_by      TEXT DEFAULT '',
+  created_at     TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS for new tables
+ALTER TABLE duplicate_dismissals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE merge_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin read dismissals" ON duplicate_dismissals
+  FOR SELECT USING (is_admin());
+CREATE POLICY "Admin write dismissals" ON duplicate_dismissals
+  FOR INSERT WITH CHECK (is_admin());
+CREATE POLICY "Admin delete dismissals" ON duplicate_dismissals
+  FOR DELETE USING (is_admin());
+
+CREATE POLICY "Admin read merge_log" ON merge_log
+  FOR SELECT USING (is_admin());
+CREATE POLICY "Admin write merge_log" ON merge_log
+  FOR INSERT WITH CHECK (is_admin());
+
+--------------------------------------------------------------------
+-- Find duplicate player candidates
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_duplicate_player_candidates(
+  min_score FLOAT DEFAULT 0.55,
+  max_results INT DEFAULT 50
+)
+RETURNS TABLE (
+  id_a TEXT, id_b TEXT,
+  name_a TEXT, name_b TEXT,
+  dob_a TEXT, dob_b TEXT,
+  nationality_a TEXT, nationality_b TEXT,
+  thumbnail_a TEXT, thumbnail_b TEXT,
+  position_a TEXT, position_b TEXT,
+  source_a TEXT, source_b TEXT,
+  transfermarkt_id_a TEXT, transfermarkt_id_b TEXT,
+  stint_count_a BIGINT, stint_count_b BIGINT,
+  score FLOAT,
+  name_sim FLOAT,
+  dob_match BOOLEAN,
+  same_nationality BOOLEAN,
+  cross_source BOOLEAN
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  WITH pairs AS (
+    SELECT
+      LEAST(a.id, b.id) AS id_a,
+      GREATEST(a.id, b.id) AS id_b,
+      CASE WHEN a.id < b.id THEN a.name ELSE b.name END AS name_a,
+      CASE WHEN a.id < b.id THEN b.name ELSE a.name END AS name_b,
+      CASE WHEN a.id < b.id THEN COALESCE(a.date_born, '') ELSE COALESCE(b.date_born, '') END AS dob_a,
+      CASE WHEN a.id < b.id THEN COALESCE(b.date_born, '') ELSE COALESCE(a.date_born, '') END AS dob_b,
+      CASE WHEN a.id < b.id THEN COALESCE(ca.name, a.nationality_id, '') ELSE COALESCE(cb.name, b.nationality_id, '') END AS nationality_a,
+      CASE WHEN a.id < b.id THEN COALESCE(cb.name, b.nationality_id, '') ELSE COALESCE(ca.name, a.nationality_id, '') END AS nationality_b,
+      CASE WHEN a.id < b.id THEN COALESCE(a.thumbnail, '') ELSE COALESCE(b.thumbnail, '') END AS thumbnail_a,
+      CASE WHEN a.id < b.id THEN COALESCE(b.thumbnail, '') ELSE COALESCE(a.thumbnail, '') END AS thumbnail_b,
+      CASE WHEN a.id < b.id THEN COALESCE(a.position, '') ELSE COALESCE(b.position, '') END AS position_a,
+      CASE WHEN a.id < b.id THEN COALESCE(b.position, '') ELSE COALESCE(a.position, '') END AS position_b,
+      CASE WHEN a.id < b.id THEN COALESCE(a.data_source, '') ELSE COALESCE(b.data_source, '') END AS source_a,
+      CASE WHEN a.id < b.id THEN COALESCE(b.data_source, '') ELSE COALESCE(a.data_source, '') END AS source_b,
+      CASE WHEN a.id < b.id THEN a.transfermarkt_id ELSE b.transfermarkt_id END AS transfermarkt_id_a,
+      CASE WHEN a.id < b.id THEN b.transfermarkt_id ELSE a.transfermarkt_id END AS transfermarkt_id_b,
+      similarity(unaccent(a.name), unaccent(b.name)) AS name_sim,
+      (COALESCE(a.date_born, '') <> '' AND a.date_born = b.date_born) AS dob_match,
+      (a.nationality_id IS NOT NULL AND a.nationality_id = b.nationality_id) AS same_nationality,
+      (COALESCE(a.data_source, '') <> COALESCE(b.data_source, '')) AS cross_source
+    FROM players a
+    JOIN players b ON a.id < b.id
+      AND unaccent(a.name) % unaccent(b.name)
+  )
+  SELECT
+    p.id_a, p.id_b,
+    p.name_a, p.name_b,
+    p.dob_a, p.dob_b,
+    p.nationality_a, p.nationality_b,
+    p.thumbnail_a, p.thumbnail_b,
+    p.position_a, p.position_b,
+    p.source_a, p.source_b,
+    p.transfermarkt_id_a, p.transfermarkt_id_b,
+    COALESCE(sa.cnt, 0) AS stint_count_a,
+    COALESCE(sb.cnt, 0) AS stint_count_b,
+    (p.name_sim
+      + CASE WHEN p.dob_match THEN 0.30 ELSE 0 END
+      + CASE WHEN p.same_nationality THEN 0.10 ELSE 0 END
+      + CASE WHEN p.cross_source THEN 0.05 ELSE 0 END
+    )::FLOAT AS score,
+    p.name_sim::FLOAT,
+    p.dob_match,
+    p.same_nationality,
+    p.cross_source
+  FROM pairs p
+  LEFT JOIN (SELECT player_id, COUNT(*) AS cnt FROM player_clubs GROUP BY player_id) sa ON sa.player_id = p.id_a
+  LEFT JOIN (SELECT player_id, COUNT(*) AS cnt FROM player_clubs GROUP BY player_id) sb ON sb.player_id = p.id_b
+  WHERE NOT EXISTS (
+    SELECT 1 FROM duplicate_dismissals d
+    WHERE d.entity_type = 'player' AND d.id_a = p.id_a AND d.id_b = p.id_b
+  )
+  AND (p.name_sim
+    + CASE WHEN p.dob_match THEN 0.30 ELSE 0 END
+    + CASE WHEN p.same_nationality THEN 0.10 ELSE 0 END
+    + CASE WHEN p.cross_source THEN 0.05 ELSE 0 END
+  ) >= min_score
+  ORDER BY score DESC
+  LIMIT max_results;
+$$;
+
+--------------------------------------------------------------------
+-- Find duplicate club candidates
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_duplicate_club_candidates(
+  min_score FLOAT DEFAULT 0.55,
+  max_results INT DEFAULT 50
+)
+RETURNS TABLE (
+  id_a TEXT, id_b TEXT,
+  name_a TEXT, name_b TEXT,
+  country_a TEXT, country_b TEXT,
+  badge_a TEXT, badge_b TEXT,
+  player_count_a BIGINT, player_count_b BIGINT,
+  score FLOAT,
+  name_sim FLOAT,
+  same_country BOOLEAN,
+  roster_overlap FLOAT,
+  shared_player_count BIGINT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  WITH pairs AS (
+    SELECT
+      LEAST(a.id, b.id) AS id_a,
+      GREATEST(a.id, b.id) AS id_b,
+      CASE WHEN a.id < b.id THEN a.name ELSE b.name END AS name_a,
+      CASE WHEN a.id < b.id THEN b.name ELSE a.name END AS name_b,
+      CASE WHEN a.id < b.id THEN COALESCE(ca.name, a.country_id, '') ELSE COALESCE(cb.name, b.country_id, '') END AS country_a,
+      CASE WHEN a.id < b.id THEN COALESCE(cb.name, b.country_id, '') ELSE COALESCE(ca.name, a.country_id, '') END AS country_b,
+      CASE WHEN a.id < b.id THEN COALESCE(a.badge, '') ELSE COALESCE(b.badge, '') END AS badge_a,
+      CASE WHEN a.id < b.id THEN COALESCE(b.badge, '') ELSE COALESCE(a.badge, '') END AS badge_b,
+      similarity(unaccent(a.name), unaccent(b.name)) AS name_sim,
+      (a.country_id IS NOT NULL AND a.country_id = b.country_id) AS same_country
+    FROM clubs a
+    JOIN clubs b ON a.id < b.id
+      AND unaccent(a.name) % unaccent(b.name)
+    LEFT JOIN countries ca ON ca.id = a.country_id
+    LEFT JOIN countries cb ON cb.id = b.country_id
+  ),
+  roster_counts AS (
+    SELECT club_id, COUNT(DISTINCT player_id) AS cnt
+    FROM player_clubs
+    GROUP BY club_id
+  ),
+  shared AS (
+    SELECT
+      LEAST(pc1.club_id, pc2.club_id) AS id_a,
+      GREATEST(pc1.club_id, pc2.club_id) AS id_b,
+      COUNT(DISTINCT pc1.player_id) AS shared_count
+    FROM player_clubs pc1
+    JOIN player_clubs pc2 ON pc1.player_id = pc2.player_id AND pc1.club_id < pc2.club_id
+    GROUP BY LEAST(pc1.club_id, pc2.club_id), GREATEST(pc1.club_id, pc2.club_id)
+  )
+  SELECT
+    p.id_a, p.id_b,
+    p.name_a, p.name_b,
+    p.country_a, p.country_b,
+    p.badge_a, p.badge_b,
+    COALESCE(ra.cnt, 0) AS player_count_a,
+    COALESCE(rb.cnt, 0) AS player_count_b,
+    (p.name_sim
+      + CASE WHEN p.same_country THEN 0.15 ELSE 0 END
+      + LEAST(0.40, 0.40 * COALESCE(s.shared_count, 0)::FLOAT / GREATEST(1, LEAST(COALESCE(ra.cnt, 0), COALESCE(rb.cnt, 0))))
+    )::FLOAT AS score,
+    p.name_sim::FLOAT,
+    p.same_country,
+    (COALESCE(s.shared_count, 0)::FLOAT / GREATEST(1, LEAST(COALESCE(ra.cnt, 0), COALESCE(rb.cnt, 0))))::FLOAT AS roster_overlap,
+    COALESCE(s.shared_count, 0) AS shared_player_count
+  FROM pairs p
+  LEFT JOIN roster_counts ra ON ra.club_id = p.id_a
+  LEFT JOIN roster_counts rb ON rb.club_id = p.id_b
+  LEFT JOIN shared s ON s.id_a = p.id_a AND s.id_b = p.id_b
+  WHERE NOT EXISTS (
+    SELECT 1 FROM duplicate_dismissals d
+    WHERE d.entity_type = 'club' AND d.id_a = p.id_a AND d.id_b = p.id_b
+  )
+  AND (p.name_sim
+    + CASE WHEN p.same_country THEN 0.15 ELSE 0 END
+    + LEAST(0.40, 0.40 * COALESCE(s.shared_count, 0)::FLOAT / GREATEST(1, LEAST(COALESCE(ra.cnt, 0), COALESCE(rb.cnt, 0))))
+  ) >= min_score
+  ORDER BY score DESC
+  LIMIT max_results;
+$$;
+
+--------------------------------------------------------------------
+-- Dismiss a duplicate pair
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION dismiss_duplicate(
+  p_entity_type TEXT,
+  p_id_a TEXT,
+  p_id_b TEXT,
+  p_reason TEXT DEFAULT ''
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  INSERT INTO duplicate_dismissals (entity_type, id_a, id_b, reason, dismissed_by)
+  VALUES (
+    p_entity_type,
+    LEAST(p_id_a, p_id_b),
+    GREATEST(p_id_a, p_id_b),
+    p_reason,
+    auth.jwt()->>'email'
+  )
+  ON CONFLICT (entity_type, id_a, id_b) DO NOTHING;
+END;
+$$;
+
+--------------------------------------------------------------------
+-- Merge two players (winner absorbs loser)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION merge_players(
+  p_winner_id TEXT,
+  p_loser_id TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_loser_snapshot JSONB;
+  v_stints_moved INT := 0;
+  v_stints_dropped INT := 0;
+  v_schedule_moved INT := 0;
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF p_winner_id = p_loser_id THEN
+    RAISE EXCEPTION 'winner and loser must be different';
+  END IF;
+
+  -- Lock both rows
+  PERFORM id FROM players WHERE id IN (p_winner_id, p_loser_id) FOR UPDATE;
+
+  -- Check both exist
+  IF NOT EXISTS (SELECT 1 FROM players WHERE id = p_winner_id) THEN
+    RAISE EXCEPTION 'winner not found';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM players WHERE id = p_loser_id) THEN
+    RAISE EXCEPTION 'loser not found';
+  END IF;
+
+  -- Refuse if both appear in same pack
+  IF EXISTS (
+    SELECT 1 FROM pack_schedule
+    WHERE p_winner_id = ANY(player_ids) AND p_loser_id = ANY(player_ids)
+  ) THEN
+    RAISE EXCEPTION 'both players appear in the same pack';
+  END IF;
+
+  -- Snapshot loser
+  SELECT jsonb_build_object(
+    'player', row_to_json(p),
+    'stints', COALESCE((
+      SELECT jsonb_agg(row_to_json(pc))
+      FROM player_clubs pc WHERE pc.player_id = p_loser_id
+    ), '[]'::jsonb)
+  ) INTO v_loser_snapshot
+  FROM players p WHERE p.id = p_loser_id;
+
+  -- Drop loser stints that would collide on (player_id, club_id, year_joined)
+  DELETE FROM player_clubs
+  WHERE player_id = p_loser_id
+    AND (club_id, year_joined) IN (
+      SELECT club_id, year_joined FROM player_clubs WHERE player_id = p_winner_id
+    );
+  GET DIAGNOSTICS v_stints_dropped = ROW_COUNT;
+
+  -- Reparent remaining loser stints
+  UPDATE player_clubs SET player_id = p_winner_id WHERE player_id = p_loser_id;
+  GET DIAGNOSTICS v_stints_moved = ROW_COUNT;
+
+  -- Reparent daily_schedule
+  UPDATE daily_schedule SET player_id = p_winner_id WHERE player_id = p_loser_id;
+  GET DIAGNOSTICS v_schedule_moved = ROW_COUNT;
+
+  -- Replace in pack_schedule arrays
+  UPDATE pack_schedule
+  SET player_ids = array_replace(player_ids, p_loser_id, p_winner_id)
+  WHERE p_loser_id = ANY(player_ids);
+
+  -- Backfill empty winner fields from loser
+  UPDATE players w SET
+    thumbnail = COALESCE(NULLIF(w.thumbnail, ''), l.thumbnail),
+    date_born = COALESCE(NULLIF(w.date_born, ''), l.date_born),
+    position = COALESCE(NULLIF(w.position, ''), l.position),
+    transfermarkt_id = CASE
+      WHEN w.transfermarkt_id IS NULL THEN l.transfermarkt_id
+      ELSE w.transfermarkt_id
+    END
+  FROM players l
+  WHERE w.id = p_winner_id AND l.id = p_loser_id;
+
+  -- Delete loser
+  DELETE FROM players WHERE id = p_loser_id;
+
+  -- Audit log
+  INSERT INTO merge_log (entity_type, winner_id, loser_id, loser_snapshot, rows_moved, merged_by)
+  VALUES (
+    'player', p_winner_id, p_loser_id, v_loser_snapshot,
+    jsonb_build_object('stints_moved', v_stints_moved, 'stints_dropped', v_stints_dropped, 'schedule_moved', v_schedule_moved),
+    auth.jwt()->>'email'
+  );
+
+  RETURN jsonb_build_object(
+    'stints_moved', v_stints_moved,
+    'stints_dropped', v_stints_dropped,
+    'schedule_moved', v_schedule_moved
+  );
+END;
+$$;
+
+--------------------------------------------------------------------
+-- Merge two clubs (winner absorbs loser)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION merge_clubs(
+  p_winner_id TEXT,
+  p_loser_id TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_loser_snapshot JSONB;
+  v_stints_moved INT := 0;
+  v_stints_dropped INT := 0;
+  v_players_updated INT := 0;
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF p_winner_id = p_loser_id THEN
+    RAISE EXCEPTION 'winner and loser must be different';
+  END IF;
+
+  -- Lock both rows
+  PERFORM id FROM clubs WHERE id IN (p_winner_id, p_loser_id) FOR UPDATE;
+
+  IF NOT EXISTS (SELECT 1 FROM clubs WHERE id = p_winner_id) THEN
+    RAISE EXCEPTION 'winner not found';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM clubs WHERE id = p_loser_id) THEN
+    RAISE EXCEPTION 'loser not found';
+  END IF;
+
+  -- Snapshot loser
+  SELECT jsonb_build_object(
+    'club', row_to_json(c),
+    'stint_count', (SELECT COUNT(*) FROM player_clubs WHERE club_id = p_loser_id)
+  ) INTO v_loser_snapshot
+  FROM clubs c WHERE c.id = p_loser_id;
+
+  -- Drop loser stints that would collide on (player_id, club_id, year_joined)
+  DELETE FROM player_clubs
+  WHERE club_id = p_loser_id
+    AND (player_id, year_joined) IN (
+      SELECT player_id, year_joined FROM player_clubs WHERE club_id = p_winner_id
+    );
+  GET DIAGNOSTICS v_stints_dropped = ROW_COUNT;
+
+  -- Reparent remaining loser stints
+  UPDATE player_clubs SET club_id = p_winner_id WHERE club_id = p_loser_id;
+  GET DIAGNOSTICS v_stints_moved = ROW_COUNT;
+
+  -- Update players.current_club_id
+  UPDATE players SET current_club_id = p_winner_id WHERE current_club_id = p_loser_id;
+  GET DIAGNOSTICS v_players_updated = ROW_COUNT;
+
+  -- Replace in pack_schedule
+  UPDATE pack_schedule SET club_id = p_winner_id WHERE club_id = p_loser_id;
+
+  -- Backfill empty winner fields
+  UPDATE clubs w SET
+    badge = COALESCE(NULLIF(w.badge, ''), l.badge),
+    league = COALESCE(NULLIF(w.league, ''), l.league),
+    country_id = COALESCE(w.country_id, l.country_id)
+  FROM clubs l
+  WHERE w.id = p_winner_id AND l.id = p_loser_id;
+
+  -- Delete loser
+  DELETE FROM clubs WHERE id = p_loser_id;
+
+  -- Audit log
+  INSERT INTO merge_log (entity_type, winner_id, loser_id, loser_snapshot, rows_moved, merged_by)
+  VALUES (
+    'club', p_winner_id, p_loser_id, v_loser_snapshot,
+    jsonb_build_object('stints_moved', v_stints_moved, 'stints_dropped', v_stints_dropped, 'players_updated', v_players_updated),
+    auth.jwt()->>'email'
+  );
+
+  RETURN jsonb_build_object(
+    'stints_moved', v_stints_moved,
+    'stints_dropped', v_stints_dropped,
+    'players_updated', v_players_updated
+  );
+END;
+$$;

--- a/supabase/migrations/013_data_cleanup.sql
+++ b/supabase/migrations/013_data_cleanup.sql
@@ -99,6 +99,8 @@ AS $$
     FROM players a
     JOIN players b ON a.id < b.id
       AND unaccent(a.name) % unaccent(b.name)
+    LEFT JOIN countries ca ON ca.id = a.nationality_id
+    LEFT JOIN countries cb ON cb.id = b.nationality_id
   )
   SELECT
     p.id_a, p.id_b,

--- a/supabase/migrations/013_data_cleanup.sql
+++ b/supabase/migrations/013_data_cleanup.sql
@@ -1,12 +1,26 @@
--- Enable pg_trgm for fuzzy name matching
+-- Enable extensions for fuzzy name matching.
+-- In this project both extensions live in the `public` schema; the wrapper
+-- below schema-qualifies the function + dictionary so it resolves regardless
+-- of the caller's search_path.
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- unaccent() is STABLE, so it can't be used directly in index expressions.
+-- Wrap it in an IMMUTABLE SQL function so we can index/match on it.
+CREATE OR REPLACE FUNCTION immutable_unaccent(text)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+  STRICT
+  AS $$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;
 
 -- GIN trigram indexes for candidate search
 CREATE INDEX IF NOT EXISTS idx_players_name_trgm
-  ON players USING gin (unaccent(name) gin_trgm_ops);
+  ON players USING gin (immutable_unaccent(name) gin_trgm_ops);
 
 CREATE INDEX IF NOT EXISTS idx_clubs_name_trgm
-  ON clubs USING gin (unaccent(name) gin_trgm_ops);
+  ON clubs USING gin (immutable_unaccent(name) gin_trgm_ops);
 
 -- Dismissed duplicate pairs (admin-rejected, order-agnostic)
 CREATE TABLE IF NOT EXISTS duplicate_dismissals (
@@ -52,6 +66,10 @@ CREATE POLICY "Admin write merge_log" ON merge_log
 --------------------------------------------------------------------
 -- Find duplicate player candidates
 --------------------------------------------------------------------
+-- Drop first so return-column changes take effect (CREATE OR REPLACE
+-- cannot alter a function's RETURNS TABLE signature).
+DROP FUNCTION IF EXISTS find_duplicate_player_candidates(FLOAT, INT);
+
 CREATE OR REPLACE FUNCTION find_duplicate_player_candidates(
   min_score FLOAT DEFAULT 0.55,
   max_results INT DEFAULT 50
@@ -73,6 +91,7 @@ RETURNS TABLE (
   cross_source BOOLEAN
 )
 LANGUAGE sql STABLE SECURITY DEFINER
+SET statement_timeout = '15s'
 AS $$
   WITH pairs AS (
     SELECT
@@ -92,13 +111,16 @@ AS $$
       CASE WHEN a.id < b.id THEN COALESCE(b.data_source, '') ELSE COALESCE(a.data_source, '') END AS source_b,
       CASE WHEN a.id < b.id THEN a.transfermarkt_id ELSE b.transfermarkt_id END AS transfermarkt_id_a,
       CASE WHEN a.id < b.id THEN b.transfermarkt_id ELSE a.transfermarkt_id END AS transfermarkt_id_b,
-      similarity(unaccent(a.name), unaccent(b.name)) AS name_sim,
+      similarity(immutable_unaccent(a.name), immutable_unaccent(b.name)) AS name_sim,
       (COALESCE(a.date_born, '') <> '' AND a.date_born = b.date_born) AS dob_match,
       (a.nationality_id IS NOT NULL AND a.nationality_id = b.nationality_id) AS same_nationality,
       (COALESCE(a.data_source, '') <> COALESCE(b.data_source, '')) AS cross_source
     FROM players a
     JOIN players b ON a.id < b.id
-      AND unaccent(a.name) % unaccent(b.name)
+      AND immutable_unaccent(a.name) % immutable_unaccent(b.name)
+      -- Hard floor on name similarity so common first-name overlaps
+      -- ("Juan García" / "Juan Pérez") don't flood the pair set.
+      AND similarity(immutable_unaccent(a.name), immutable_unaccent(b.name)) >= 0.45
     LEFT JOIN countries ca ON ca.id = a.nationality_id
     LEFT JOIN countries cb ON cb.id = b.nationality_id
   )
@@ -141,6 +163,8 @@ $$;
 --------------------------------------------------------------------
 -- Find duplicate club candidates
 --------------------------------------------------------------------
+DROP FUNCTION IF EXISTS find_duplicate_club_candidates(FLOAT, INT);
+
 CREATE OR REPLACE FUNCTION find_duplicate_club_candidates(
   min_score FLOAT DEFAULT 0.55,
   max_results INT DEFAULT 50
@@ -158,6 +182,7 @@ RETURNS TABLE (
   shared_player_count BIGINT
 )
 LANGUAGE sql STABLE SECURITY DEFINER
+SET statement_timeout = '15s'
 AS $$
   WITH pairs AS (
     SELECT
@@ -169,11 +194,12 @@ AS $$
       CASE WHEN a.id < b.id THEN COALESCE(cb.name, b.country_id, '') ELSE COALESCE(ca.name, a.country_id, '') END AS country_b,
       CASE WHEN a.id < b.id THEN COALESCE(a.badge, '') ELSE COALESCE(b.badge, '') END AS badge_a,
       CASE WHEN a.id < b.id THEN COALESCE(b.badge, '') ELSE COALESCE(a.badge, '') END AS badge_b,
-      similarity(unaccent(a.name), unaccent(b.name)) AS name_sim,
+      similarity(immutable_unaccent(a.name), immutable_unaccent(b.name)) AS name_sim,
       (a.country_id IS NOT NULL AND a.country_id = b.country_id) AS same_country
     FROM clubs a
     JOIN clubs b ON a.id < b.id
-      AND unaccent(a.name) % unaccent(b.name)
+      AND immutable_unaccent(a.name) % immutable_unaccent(b.name)
+      AND similarity(immutable_unaccent(a.name), immutable_unaccent(b.name)) >= 0.45
     LEFT JOIN countries ca ON ca.id = a.country_id
     LEFT JOIN countries cb ON cb.id = b.country_id
   ),
@@ -225,6 +251,8 @@ $$;
 --------------------------------------------------------------------
 -- Dismiss a duplicate pair
 --------------------------------------------------------------------
+DROP FUNCTION IF EXISTS dismiss_duplicate(TEXT, TEXT, TEXT, TEXT);
+
 CREATE OR REPLACE FUNCTION dismiss_duplicate(
   p_entity_type TEXT,
   p_id_a TEXT,
@@ -254,6 +282,8 @@ $$;
 --------------------------------------------------------------------
 -- Merge two players (winner absorbs loser)
 --------------------------------------------------------------------
+DROP FUNCTION IF EXISTS merge_players(TEXT, TEXT);
+
 CREATE OR REPLACE FUNCTION merge_players(
   p_winner_id TEXT,
   p_loser_id TEXT
@@ -359,6 +389,8 @@ $$;
 --------------------------------------------------------------------
 -- Merge two clubs (winner absorbs loser)
 --------------------------------------------------------------------
+DROP FUNCTION IF EXISTS merge_clubs(TEXT, TEXT);
+
 CREATE OR REPLACE FUNCTION merge_clubs(
   p_winner_id TEXT,
   p_loser_id TEXT

--- a/supabase/migrations/014_stint_orphan_cleanup.sql
+++ b/supabase/migrations/014_stint_orphan_cleanup.sql
@@ -1,0 +1,233 @@
+--------------------------------------------------------------------
+-- Find fragmented stints: (player, club) pairs with ≥2 overlapping
+-- or adjacent rows (year ranges within 1 year of each other)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_fragmented_stints(
+  max_results INT DEFAULT 100
+)
+RETURNS TABLE (
+  player_id TEXT,
+  player_name TEXT,
+  club_id TEXT,
+  club_name TEXT,
+  stint_count BIGINT,
+  earliest_joined TEXT,
+  latest_departed TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT
+    pc.player_id,
+    p.name AS player_name,
+    pc.club_id,
+    c.name AS club_name,
+    COUNT(*) AS stint_count,
+    MIN(NULLIF(pc.year_joined, '')) AS earliest_joined,
+    CASE
+      WHEN BOOL_OR(COALESCE(pc.year_departed, '') = '') THEN ''
+      ELSE MAX(pc.year_departed)
+    END AS latest_departed
+  FROM player_clubs pc
+  JOIN players p ON p.id = pc.player_id
+  JOIN clubs c ON c.id = pc.club_id
+  GROUP BY pc.player_id, p.name, pc.club_id, c.name
+  HAVING COUNT(*) >= 2
+  ORDER BY COUNT(*) DESC, p.name
+  LIMIT max_results;
+$$;
+
+--------------------------------------------------------------------
+-- Merge stints for a (player, club) pair into a single row:
+-- keeps earliest year_joined and latest year_departed, deletes extras
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION merge_stints(
+  p_player_id TEXT,
+  p_club_id TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_count INT;
+  v_earliest TEXT;
+  v_latest TEXT;
+  v_has_ongoing BOOLEAN;
+  v_keep_id BIGINT;
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM player_clubs
+  WHERE player_id = p_player_id AND club_id = p_club_id;
+
+  IF v_count < 2 THEN
+    RAISE EXCEPTION 'nothing to merge — fewer than 2 stints';
+  END IF;
+
+  -- Compute the merged range
+  SELECT
+    MIN(NULLIF(year_joined, '')),
+    MAX(year_departed),
+    BOOL_OR(COALESCE(year_departed, '') = '')
+  INTO v_earliest, v_latest, v_has_ongoing
+  FROM player_clubs
+  WHERE player_id = p_player_id AND club_id = p_club_id;
+
+  IF v_has_ongoing THEN
+    v_latest := '';
+  END IF;
+
+  -- Pick one row to keep (lowest id)
+  SELECT id INTO v_keep_id
+  FROM player_clubs
+  WHERE player_id = p_player_id AND club_id = p_club_id
+  ORDER BY id
+  LIMIT 1;
+
+  -- Delete all other rows
+  DELETE FROM player_clubs
+  WHERE player_id = p_player_id AND club_id = p_club_id AND id <> v_keep_id;
+
+  -- Update the kept row with merged range
+  UPDATE player_clubs
+  SET year_joined = COALESCE(v_earliest, ''),
+      year_departed = COALESCE(v_latest, '')
+  WHERE id = v_keep_id;
+
+  RETURN jsonb_build_object(
+    'stints_merged', v_count,
+    'kept_joined', COALESCE(v_earliest, ''),
+    'kept_departed', COALESCE(v_latest, '')
+  );
+END;
+$$;
+
+--------------------------------------------------------------------
+-- Find orphan players (0 club stints, not in any schedule)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_orphan_players(
+  max_results INT DEFAULT 100
+)
+RETURNS TABLE (
+  id TEXT,
+  name TEXT,
+  date_born TEXT,
+  nationality TEXT,
+  data_source TEXT,
+  thumbnail TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT
+    p.id,
+    p.name,
+    COALESCE(p.date_born, '') AS date_born,
+    COALESCE(c.name, p.nationality_id, '') AS nationality,
+    COALESCE(p.data_source, '') AS data_source,
+    COALESCE(p.thumbnail, '') AS thumbnail
+  FROM players p
+  LEFT JOIN countries c ON c.id = p.nationality_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM player_clubs pc WHERE pc.player_id = p.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM daily_schedule ds WHERE ds.player_id = p.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pack_schedule ps WHERE p.id = ANY(ps.player_ids)
+  )
+  ORDER BY p.name
+  LIMIT max_results;
+$$;
+
+--------------------------------------------------------------------
+-- Find orphan clubs (0 player stints, not referenced elsewhere)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_orphan_clubs(
+  max_results INT DEFAULT 100
+)
+RETURNS TABLE (
+  id TEXT,
+  name TEXT,
+  country TEXT,
+  badge TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT
+    cl.id,
+    cl.name,
+    COALESCE(co.name, cl.country_id, '') AS country,
+    COALESCE(cl.badge, '') AS badge
+  FROM clubs cl
+  LEFT JOIN countries co ON co.id = cl.country_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM player_clubs pc WHERE pc.club_id = cl.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM players p WHERE p.current_club_id = cl.id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM pack_schedule ps WHERE ps.club_id = cl.id
+  )
+  ORDER BY cl.name
+  LIMIT max_results;
+$$;
+
+--------------------------------------------------------------------
+-- Delete an orphan player (only if truly orphaned)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION delete_orphan_player(p_id TEXT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM player_clubs WHERE player_id = p_id) THEN
+    RAISE EXCEPTION 'player still has stints — not an orphan';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM daily_schedule WHERE player_id = p_id) THEN
+    RAISE EXCEPTION 'player is in daily schedule — not safe to delete';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pack_schedule WHERE p_id = ANY(player_ids)) THEN
+    RAISE EXCEPTION 'player is in a pack — not safe to delete';
+  END IF;
+
+  DELETE FROM players WHERE id = p_id;
+END;
+$$;
+
+--------------------------------------------------------------------
+-- Delete an orphan club (only if truly orphaned)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION delete_orphan_club(p_id TEXT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  IF NOT is_admin() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM player_clubs WHERE club_id = p_id) THEN
+    RAISE EXCEPTION 'club still has stints — not an orphan';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM players WHERE current_club_id = p_id) THEN
+    RAISE EXCEPTION 'club is a current club for a player — not safe to delete';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pack_schedule WHERE club_id = p_id) THEN
+    RAISE EXCEPTION 'club is in a pack — not safe to delete';
+  END IF;
+
+  DELETE FROM clubs WHERE id = p_id;
+END;
+$$;

--- a/supabase/migrations/015_shared_data_queries.sql
+++ b/supabase/migrations/015_shared_data_queries.sql
@@ -1,0 +1,57 @@
+--------------------------------------------------------------------
+-- Find clubs that both players have stints at (shared club history)
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_shared_clubs_for_players(
+  p_player_a TEXT,
+  p_player_b TEXT
+)
+RETURNS TABLE (
+  club_id TEXT,
+  club_name TEXT,
+  club_badge TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT c.id, c.name, COALESCE(c.badge, '')
+  FROM player_clubs pc
+  JOIN clubs c ON c.id = pc.club_id
+  WHERE pc.player_id IN (p_player_a, p_player_b)
+  GROUP BY c.id, c.name, c.badge
+  HAVING COUNT(DISTINCT pc.player_id) = 2
+  ORDER BY c.name;
+$$;
+
+--------------------------------------------------------------------
+-- Find players that have stints at both clubs (roster overlap preview)
+-- Returns year ranges at each club for admin sanity-checking
+--------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION find_shared_players_for_clubs(
+  p_club_a TEXT,
+  p_club_b TEXT
+)
+RETURNS TABLE (
+  player_id TEXT,
+  player_name TEXT,
+  years_at_a TEXT,
+  years_at_b TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT
+    p.id,
+    p.name,
+    (SELECT string_agg(
+      COALESCE(NULLIF(pc1.year_joined, ''), '?') || '–' || COALESCE(NULLIF(pc1.year_departed, ''), 'present'),
+      ', ' ORDER BY pc1.year_joined
+    ) FROM player_clubs pc1 WHERE pc1.player_id = p.id AND pc1.club_id = p_club_a),
+    (SELECT string_agg(
+      COALESCE(NULLIF(pc2.year_joined, ''), '?') || '–' || COALESCE(NULLIF(pc2.year_departed, ''), 'present'),
+      ', ' ORDER BY pc2.year_joined
+    ) FROM player_clubs pc2 WHERE pc2.player_id = p.id AND pc2.club_id = p_club_b)
+  FROM player_clubs pc
+  JOIN players p ON p.id = pc.player_id
+  WHERE pc.club_id IN (p_club_a, p_club_b)
+  GROUP BY p.id, p.name
+  HAVING COUNT(DISTINCT pc.club_id) = 2
+  ORDER BY p.name;
+$$;


### PR DESCRIPTION
## Summary
- Adds a Data Cleanup tab to the Admin interface for surfacing and resolving duplicate players/clubs from layered imports (TransferMarkt, Wikidata, SportsDB)
- Includes 4 sub-queues: duplicate players, duplicate clubs, fragmented stints, and orphan records
- Two SQL migrations (013, 014) add trigram-based duplicate detection RPCs, merge functions with audit logging, stint consolidation, and orphan cleanup — all gated via `is_admin()`
- Shared club history + roster overlap preview to help judge merges
- Conflicting fields (DOB, nationality, position, country) highlighted in red

## Test plan
- [ ] Apply migrations 013 and 014 to staging
- [ ] Verify duplicate candidate scoring on real data (player name similarity + DOB/nationality, club name similarity + roster overlap)
- [ ] Test merge flow: confirm winner selection, merge execution, and merge_log audit entry
- [ ] Test dismiss flow: ensure dismissed pairs don't reappear
- [ ] Test stint cleanup: verify fragmented stints merge correctly preserving full year range
- [ ] Test orphan cleanup: verify orphan detection excludes schedule/pack-referenced records

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)