### PR TITLE
feat(admin): allow same-year loan stints and add suggestion shuffle

### DIFF
--- a/scripts/backfill-wikidata.ts
+++ b/scripts/backfill-wikidata.ts
@@ -312,7 +312,7 @@ async function main() {
       }
       // Then player_clubs
       pcInserted += pcBatch.length;
-      await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined");
+      await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined,is_loan");
       pcBatch.length = 0;
     }
 
@@ -329,7 +329,7 @@ async function main() {
       await upsertBatch("clubs", newClubs, undefined, true);
     }
     pcInserted += pcBatch.length;
-    await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined");
+    await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined,is_loan");
   }
 
   console.log(`\n=== Results ===`);

--- a/scripts/import-transfermarkt.ts
+++ b/scripts/import-transfermarkt.ts
@@ -299,13 +299,13 @@ async function main() {
       pcTotal++;
 
       if (pcBatch.length >= 500) {
-        await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined");
+        await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined,is_loan");
         pcBatch.length = 0;
       }
     }
   }
   if (pcBatch.length > 0) {
-    await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined");
+    await upsertBatch("player_clubs", pcBatch, "player_id,club_id,year_joined,is_loan");
   }
   console.log(`  Inserted ${pcTotal} player-club records`);
 

--- a/scripts/seed-players.ts
+++ b/scripts/seed-players.ts
@@ -215,7 +215,7 @@ async function seedPlayer(player: { id: string; name: string; thumbnail: string;
     }));
     const { error } = await supabase
       .from("player_clubs")
-      .upsert(rows, { onConflict: "player_id,club_id,year_joined" });
+      .upsert(rows, { onConflict: "player_id,club_id,year_joined,is_loan" });
     if (error) {
       console.warn(`    Failed to upsert clubs: ${error.message}`);
     } else {

--- a/src/__tests__/adminHelpers.test.ts
+++ b/src/__tests__/adminHelpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { reshuffleSuggestions } from "../pages/Admin/helpers";
+import type { DayState } from "../pages/Admin/types";
+import type { Player } from "../types";
+
+function player(id: string): Player {
+  return { id, name: `Player ${id}`, thumbnail: "", nationality: "Norway" };
+}
+
+function day(date: string, assigned: Player | null = null, suggestion: Player | null = null): DayState {
+  return { date, assignedPlayer: assigned, suggestion };
+}
+
+const TODAY = "2026-06-10";
+
+describe("reshuffleSuggestions", () => {
+  it("leaves past days and assigned days untouched", () => {
+    const past = day("2026-06-09", null, player("old"));
+    const assigned = day("2026-06-10", player("a"), null);
+    const open = day("2026-06-11");
+    const result = reshuffleSuggestions([past, assigned, open], [player("x")], TODAY, () => 0);
+    expect(result[0]).toBe(past);
+    expect(result[1]).toBe(assigned);
+    expect(result[2].suggestion?.id).toBe("x");
+  });
+
+  it("fills open days from the pool without repeats", () => {
+    const days = [day("2026-06-10"), day("2026-06-11"), day("2026-06-12")];
+    const pool = [player("a"), player("b"), player("c"), player("d")];
+    const result = reshuffleSuggestions(days, pool, TODAY);
+    const ids = result.map((d) => d.suggestion!.id);
+    expect(new Set(ids).size).toBe(3);
+    for (const id of ids) expect(pool.some((p) => p.id === id)).toBe(true);
+  });
+
+  it("sets suggestion to null when the pool runs out", () => {
+    const days = [day("2026-06-10"), day("2026-06-11")];
+    const result = reshuffleSuggestions(days, [player("only")], TODAY);
+    expect(result[0].suggestion?.id).toBe("only");
+    expect(result[1].suggestion).toBeNull();
+  });
+
+  it("is deterministic with an injected random source", () => {
+    const days = [day("2026-06-10"), day("2026-06-11")];
+    const pool = [player("a"), player("b"), player("c")];
+    const r1 = reshuffleSuggestions(days, pool, TODAY, () => 0.5);
+    const r2 = reshuffleSuggestions(days, pool, TODAY, () => 0.5);
+    expect(r1.map((d) => d.suggestion?.id)).toEqual(r2.map((d) => d.suggestion?.id));
+  });
+
+  it("does not mutate the input arrays", () => {
+    const days = [day("2026-06-10")];
+    const pool = [player("a"), player("b")];
+    const poolCopy = [...pool];
+    reshuffleSuggestions(days, pool, TODAY);
+    expect(days[0].suggestion).toBeNull();
+    expect(pool).toEqual(poolCopy);
+  });
+});

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -198,6 +198,7 @@ export async function addPlayerClub(
   clubId: string,
   yearJoined: string,
   yearDeparted: string,
+  isLoan = false,
 ): Promise<AdminClubRow | null> {
   if (!supabase) return null;
 
@@ -227,6 +228,7 @@ export async function addPlayerClub(
       club_id: clubId,
       year_joined: yearJoined,
       year_departed: yearDeparted,
+      is_loan: isLoan,
       sort_order: nextSortOrder,
     })
     .select("id, club_id, year_joined, year_departed, is_hidden, is_youth_team, is_loan, sort_order, clubs(name, badge)")

--- a/src/pages/Admin/AddClubForm.tsx
+++ b/src/pages/Admin/AddClubForm.tsx
@@ -21,6 +21,7 @@ export default function AddClubForm({ playerId, onAdded }: Props) {
   const [yearJoined, setYearJoined] = useState("");
   const [yearDeparted, setYearDeparted] = useState("");
   const [isPresent, setIsPresent] = useState(false);
+  const [isLoan, setIsLoan] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
@@ -65,6 +66,7 @@ export default function AddClubForm({ playerId, onAdded }: Props) {
     setYearJoined("");
     setYearDeparted("");
     setIsPresent(false);
+    setIsLoan(false);
     setError(null);
   }
 
@@ -84,10 +86,10 @@ export default function AddClubForm({ playerId, onAdded }: Props) {
       return;
     }
     setSaving(true);
-    const row = await addPlayerClub(playerId, selected.id, yearJoined, departed);
+    const row = await addPlayerClub(playerId, selected.id, yearJoined, departed, isLoan);
     setSaving(false);
     if (!row) {
-      setError("Failed to add club. It may already exist for this player+year.");
+      setError("Failed to add club. A stint at this club with the same joined year and loan status may already exist.");
       return;
     }
     onAdded(row);
@@ -158,6 +160,15 @@ export default function AddClubForm({ playerId, onAdded }: Props) {
             className="accent-green-500 w-3.5 h-3.5"
           />
           <span className="text-xs text-gray-300">Present</span>
+        </label>
+        <label className="flex items-center gap-1.5 cursor-pointer" title="Loan spell">
+          <input
+            type="checkbox"
+            checked={isLoan}
+            onChange={(e) => setIsLoan(e.target.checked)}
+            className="accent-blue-500 w-3.5 h-3.5"
+          />
+          <span className={`text-xs ${isLoan ? "text-blue-400" : "text-gray-300"}`}>Loan</span>
         </label>
         <button
           type="button"

--- a/src/pages/Admin/ScheduleManager.tsx
+++ b/src/pages/Admin/ScheduleManager.tsx
@@ -3,6 +3,8 @@ import { SEED_PLAYERS } from "../../data/seedPlayers";
 import { getAllScheduledDays } from "../../api/dailySchedule";
 import { upsertSchedule, deleteSchedule, getScheduleRange, getPlayerThumbnails, getPlayersByIds } from "../../api/adminApi";
 import { SCHEDULE_DAYS_AHEAD, SCHEDULE_DAYS_BACK } from "./constants";
+import { reshuffleSuggestions } from "./helpers";
+import type { DayState } from "./types";
 import type { Player } from "../../types";
 import PlayerSearch from "../../components/PlayerSearch";
 import PlayerClubList from "./PlayerClubList";
@@ -27,15 +29,10 @@ function getDateRange(daysBack: number, daysAhead: number): string[] {
   return dates;
 }
 
-interface DayState {
-  date: string;
-  assignedPlayer: Player | null;
-  suggestion: Player | null;
-}
-
 export default function ScheduleManager() {
   const [days, setDays] = useState<DayState[]>([]);
   const [usedPlayerIds, setUsedPlayerIds] = useState<Set<string>>(new Set());
+  const [thumbnails, setThumbnails] = useState<Map<string, string>>(new Map());
   const [scheduledPlayerLabels, setScheduledPlayerLabels] = useState<Map<string, string>>(new Map());
   const [expandedDate, setExpandedDate] = useState<string | null>(null);
   const [showPast, setShowPast] = useState(false);
@@ -77,6 +74,7 @@ export default function ScheduleManager() {
 
     // Fetch fresh thumbnails from the database (seed data may have stale URLs)
     const thumbnails = await getPlayerThumbnails(SEED_PLAYERS.map((p) => p.id));
+    setThumbnails(thumbnails);
     const withFreshThumbs = (p: Player): Player =>
       thumbnails.has(p.id) ? { ...p, thumbnail: thumbnails.get(p.id)! } : p;
 
@@ -207,18 +205,38 @@ export default function ScheduleManager() {
     setExpandedDate((prev) => (prev === date ? null : date));
   }, []);
 
+  const handleShuffle = useCallback(() => {
+    const pool = SEED_PLAYERS
+      .filter((p) => !usedPlayerIds.has(p.id))
+      .map((p) => (thumbnails.has(p.id) ? { ...p, thumbnail: thumbnails.get(p.id)! } : p));
+    setDays((prev) => reshuffleSuggestions(prev, pool, today));
+  }, [usedPlayerIds, thumbnails, today]);
+
   if (loading) {
     return <p className="text-gray-400 text-center py-8">Loading schedule...</p>;
   }
 
   return (
     <div className="space-y-2">
-      <h2 className="text-lg font-semibold mb-4">
-        Daily Schedule
-        <span className="text-gray-400 text-sm font-normal ml-2">
-          {SEED_PLAYERS.length - usedPlayerIds.size} seed players remaining
-        </span>
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">
+          Daily Schedule
+          <span className="text-gray-400 text-sm font-normal ml-2">
+            {SEED_PLAYERS.length - usedPlayerIds.size} seed players remaining
+          </span>
+        </h2>
+        <button
+          onClick={handleShuffle}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
+          title="Re-roll the suggested players for all open days"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          Shuffle suggestions
+        </button>
+      </div>
 
       <div className="mb-4">
         <PlayerSearch

--- a/src/pages/Admin/helpers.ts
+++ b/src/pages/Admin/helpers.ts
@@ -1,0 +1,26 @@
+import type { Player } from "../../types";
+import type { DayState } from "./types";
+
+/**
+ * Re-roll the suggestions for all open (unassigned, non-past) days from the
+ * given pool of unused players. Assigned and past days are left untouched.
+ * `random` is injectable for deterministic tests.
+ */
+export function reshuffleSuggestions(
+  days: DayState[],
+  pool: Player[],
+  today: string,
+  random: () => number = Math.random,
+): DayState[] {
+  const shuffled = [...pool];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  let idx = 0;
+  return days.map((day) => {
+    if (day.date < today || day.assignedPlayer) return day;
+    return { ...day, suggestion: shuffled[idx++] ?? null };
+  });
+}

--- a/src/pages/Admin/types.ts
+++ b/src/pages/Admin/types.ts
@@ -1,5 +1,11 @@
 import type { Player } from "../../types";
 
+export interface DayState {
+  date: string;
+  assignedPlayer: Player | null;
+  suggestion: Player | null;
+}
+
 export interface ScheduleEntry {
   date: string;
   player: Player | null;

--- a/supabase/migrations/013_loan_in_unique_constraint.sql
+++ b/supabase/migrations/013_loan_in_unique_constraint.sql
@@ -1,0 +1,13 @@
+-- Allow a loan spell and a permanent spell at the same club starting the same
+-- year (e.g. loan in January, signed permanently in July). The original
+-- UNIQUE (player_id, club_id, year_joined) rejected the second row.
+-- Import/backfill scripts upsert with the matching conflict target
+-- "player_id,club_id,year_joined,is_loan" (their rows default is_loan = false,
+-- so script dedup behaviour is unchanged).
+
+ALTER TABLE player_clubs
+  DROP CONSTRAINT IF EXISTS player_clubs_player_id_club_id_year_joined_key;
+
+ALTER TABLE player_clubs
+  ADD CONSTRAINT player_clubs_player_club_year_loan_key
+  UNIQUE (player_id, club_id, year_joined, is_loan);


### PR DESCRIPTION
## What

Two admin quality-of-life fixes:

1. **Same-year loan stints.** The `UNIQUE (player_id, club_id, year_joined)` constraint rejected adding a loan spell and a permanent spell at the same club starting the same year (e.g. loan in January, signed in July). Migration `013` extends the constraint with `is_loan`, and the add-club form gets a **Loan** checkbox so the stint can be created as a loan directly. The import/backfill scripts' upsert conflict targets are updated to match (their rows default `is_loan = false`, so script dedup behaviour is unchanged).

2. **Shuffle suggestions.** Getting a fresh set of suggested players required a full page reload. A "Shuffle suggestions" button in the Daily Schedule header re-rolls suggestions for all open (unassigned, future) days, keeping past/approved days untouched. Logic extracted to a pure `reshuffleSuggestions` helper with unit tests.

## ⚠️ Migration required

`supabase/migrations/013_loan_in_unique_constraint.sql` must be pasted into the SQL Editor (staging + production). Safe in any order relative to deploy:
- The app and currently-deployed code don't depend on the old constraint shape.
- The updated scripts (`import-transfermarkt`, `backfill-wikidata`, `seed-players`) only run manually, and require the new constraint when they do.

## Testing

- `npm test` — 131 tests pass (5 new for `reshuffleSuggestions`)
- `tsc -b` and lint clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)